### PR TITLE
stream updates from the transactor rpc service

### DIFF
--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -34,3 +34,15 @@ class TransactorClient(object):
         req = Transactor_pb2.UpdateRequest(chainCellCbor=cell.to_cbor_bytes())
         ref = self.client.UpdateChain(req, timeout)
         return MultihashReference.from_base58(ref.reference)
+
+    def journal_stream(self, last_block_ref=None, timeout=TIMEOUT_SECS):
+        if isinstance(last_block_ref, MultihashReference):
+            last_block_ref = Transactor_pb2.MultihashReference(
+                reference=last_block_ref.multihash_base58())
+        elif last_block_ref is not None:
+            last_block_ref = Transactor_pb2.MultihashReference(
+                reference=last_block_ref)
+
+        req = Transactor_pb2.JournalStreamRequest(
+            lastJournalBlock=last_block_ref)
+        return self.client.JournalStream(req, timeout)

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -37,12 +37,10 @@ class TransactorClient(object):
 
     def journal_stream(self, last_block_ref=None, timeout=TIMEOUT_SECS):
         if isinstance(last_block_ref, MultihashReference):
-            last_block_ref = Transactor_pb2.MultihashReference(
-                reference=last_block_ref.multihash_base58())
-        elif last_block_ref is not None:
-            last_block_ref = Transactor_pb2.MultihashReference(
-                reference=last_block_ref)
+            last_block_ref = last_block_ref.multihash_base58()
 
         req = Transactor_pb2.JournalStreamRequest(
-            lastJournalBlock=last_block_ref)
+            lastJournalBlock=Transactor_pb2.MultihashReference(
+                reference=last_block_ref
+            ))
         return self.client.JournalStream(req, timeout)


### PR DESCRIPTION
This depends on the in-progress branch on the server: https://github.com/mediachain/mediachain/pull/117

Until that's merged in, you'll need to manually compile the protobufs from that branch.  Assuming you've got that branch checked out in the `../mediachain` directory, and `protoc` is installed:

``` bash
protoc -I ../mediachain/protocol/src/main/protobuf/ --python_out=./mediachain/proto --grpc_out=./mediachain/proto --plugin=protoc-gen-grpc=`which grpc_python_plugin` ../mediachain/protocol/src/main/protobuf/Transactor.proto
```

So far this just adds a `journal_stream` method to `TransactorClient` that returns a generator of journal events.  It accepts an optional "last block" reference as either a base58 string or a `datastore.data_objects.MultihashReference`, but that's not wired up on the server yet.  

The events look like this:

```
canonicalInserted {
  reference: "QmUhAiKRF8AbSeaqYZRyCui3aAzdraCi6zpodM9vfW1oKP"
}

chainUpdated {
  canonical {
    reference: "QmUhAiKRF8AbSeaqYZRyCui3aAzdraCi6zpodM9vfW1oKP"
  }
  chain {
    reference: "QmTscXnpKKdJQs2e5uv3h1W4aCZAVan3LgY2vCCwJ8dcHA"
  }
}
```

and you can iterate over them with something like

``` python
for e in client.journal_stream():
    print("got journal event: " + str(e))
```

because the journal event message uses a `oneof` field, only one of `canonicalInserted`, `chainUpdated`, or `journalBlockPublished` will be set to a value; the others will be `None`.

`canonicalInserted` and `journalBlockPublished` are `MultihashReference`s, and you can get the base58 representation with e.g. `canonicalInserted.reference`.  `chainUpdated` is a struct that contains refs to the canonical, the new head of that canonical's chain and the previous head (if any).

To make sense of the events, you'll need to fetch the referenced objects from the datastore.
