### PR TITLE
add IpfsDatastore, only use for rawRef to avoid confusing the transactor

### DIFF
--- a/mediachain/datastore/data_objects.py
+++ b/mediachain/datastore/data_objects.py
@@ -1,18 +1,8 @@
 import cbor
 from base58 import b58encode, b58decode
-from tempfile import NamedTemporaryFile
-from multihash import SHA2_256
-import ipfsApi
+from multihash import SHA2_256, encode as multihash_encode
 import pprint
 
-# DEMO PURPOSES ONLY
-def multihash_encode(b, _):
-    ipfs = ipfsApi.Client('127.0.0.1', 5001)
-    with NamedTemporaryFile() as f:
-        f.write(b)
-        f.flush()
-        m = ipfs.add(f.name)
-        return b58decode(m)
 
 class Record(object):
     meta = dict()

--- a/mediachain/datastore/ipfs.py
+++ b/mediachain/datastore/ipfs.py
@@ -1,0 +1,30 @@
+import ipfsApi
+import cbor
+from tempfile import NamedTemporaryFile
+from mediachain.datastore.data_objects import Record, MultihashReference
+
+
+class IpfsDatastore(object):
+    def __init__(self, host='127.0.0.1', port=5001):
+        self.client = ipfsApi.Client(host, port)
+
+    def put(self, data_object):
+        if isinstance(data_object, Record):
+            content = data_object.to_cbor_bytes()
+        else:
+            content = data_object
+
+        with NamedTemporaryFile() as f:
+            f.write(content)
+            f.flush()
+            result = self.client.add(f.name)
+        return result[1][u'Hash']
+
+    def get(self, ref):
+        if isinstance(ref, MultihashReference):
+            ref_multihash = ref.multihash_base58()
+        else:
+            ref_multihash = ref
+
+        byte_string = self.client.object_data(ref_multihash)
+        return cbor.loads(byte_string)

--- a/mediachain/datastore/ipfs.py
+++ b/mediachain/datastore/ipfs.py
@@ -29,6 +29,9 @@ class IpfsDatastore(object):
         # followed by entries for the file, plus entries for '/tmp', '/tmp/foo',
         # etc.
         header = result.pop(0)
+        if 'Hash' in header:
+            return header['Hash']
+
         name = header['Name']
         hashes = [h['Hash'] for h in result if h['Name'] == name]
         return hashes[0]

--- a/mediachain/getty/ingest.py
+++ b/mediachain/getty/ingest.py
@@ -10,6 +10,7 @@ from mediachain.datastore.data_objects import Artefact, Entity, \
 from mediachain.datastore.dynamo import get_db
 from mediachain.datastore.ipfs import IpfsDatastore
 from mediachain.transactor.client import TransactorClient
+from mediachain.getty.thumbnails import get_thumbnail_data, make_jpeg_data_uri
 
 TRANSLATOR_ID = u'GettyTranslator/0.1'
 
@@ -30,7 +31,8 @@ def ingest(host, port, dir_root, max_num=0):
         print("RPC Error: " + str(e))
 
 
-def getty_to_mediachain_objects(transactor, raw_ref, getty_json, entities):
+def getty_to_mediachain_objects(transactor, raw_ref, getty_json, entities,
+                                thumbnail_ref=None, thumbnail_uri=None):
     common_meta = {u'rawRef': raw_ref.to_map(),
                    u'translatedAt': unicode(datetime.utcnow().isoformat()),
                    u'translator': TRANSLATOR_ID}
@@ -54,6 +56,14 @@ def getty_to_mediachain_objects(transactor, raw_ref, getty_json, entities):
                 [x['text'] for x in getty_json['keywords'] if 'text' in x],
             u'date_created': getty_json['date_created']
             }
+
+    if thumbnail_ref is not None:
+        m = MultihashReference.from_base58(thumbnail_ref)
+        data[u'thumbnail'] = m.to_map()
+
+    if thumbnail_uri is not None:
+        data[u'thumbnail_base64'] = thumbnail_uri
+
     artefact_meta = deepcopy(common_meta)
     artefact_meta.update({u'data': data})
 
@@ -74,11 +84,22 @@ def getty_artefacts(transactor,
                     max_num=0):
     entities = dedup_artists(transactor, datastore, dd, max_num)
 
-    for content, getty_json in walk_json_dir(dd, max_num):
+    for content, file_name in walk_json_dir(dd, max_num):
         raw_ref_str = put_raw_data(content)
         raw_ref = MultihashReference.from_base58(raw_ref_str)
+        getty_json = json.loads(content.decode('utf-8'))
+
+        thumbnail_data = get_thumbnail_data(file_name)
+        if thumbnail_data is not None:
+            thumbnail_ref = put_raw_data(thumbnail_data)
+            thumbnail_uri = make_jpeg_data_uri(thumbnail_data)
+        else:
+            thumbnail_ref = None
+            thumbnail_uri = None
+
         yield getty_to_mediachain_objects(
-            transactor, raw_ref, getty_json, entities
+            transactor, raw_ref, getty_json, entities,
+            thumbnail_ref=thumbnail_ref, thumbnail_uri=thumbnail_uri
         )
 
 
@@ -90,7 +111,8 @@ def dedup_artists(transactor,
     artist_name_map = {}
     total_parsed = 0
     unique = 0
-    for content, getty_json in walk_json_dir(dd, max_num):
+    for content, _ in walk_json_dir(dd, max_num):
+        getty_json = json.loads(content.decode('utf-8'))
         total_parsed += 1
         n = getty_json['artist']
         if n is None or n in artist_name_map:
@@ -128,7 +150,7 @@ def walk_json_dir(dd='getty',
     for dir_name, subdir_list, file_list in walk(dd):
         for fn in file_list:
             ext = path.splitext(fn)[-1]
-            if ext.lower() != 'json':
+            if ext.lower() != '.json':
                 continue
 
             nn += 1
@@ -142,11 +164,11 @@ def walk_json_dir(dd='getty',
             with open(fn, mode='rb') as f:
                 try:
                     content = f.read()
-                    decoded_json = json.loads(content.decode('utf-8'))
-                    yield content, decoded_json
                 except ValueError:
                     print "couldn't import json from {}".format(fn)
                     continue
+                yield content, fn
+
 
 
 def put_raw_data(raw):

--- a/mediachain/getty/ingest.py
+++ b/mediachain/getty/ingest.py
@@ -2,9 +2,7 @@ import json
 import sys
 from copy import deepcopy
 from datetime import datetime
-from os import walk
-from os.path import join
-
+from os import walk, path
 from grpc.framework.interfaces.face.face import AbortionError
 
 from mediachain.datastore.data_objects import Artefact, Entity, \
@@ -124,18 +122,22 @@ def dedup_artists(transactor,
     return entities
 
 
-def walk_json_dir(dd='getty/json/images',
+def walk_json_dir(dd='getty',
                   max_num=0):
     nn = 0
     for dir_name, subdir_list, file_list in walk(dd):
         for fn in file_list:
+            ext = path.splitext(fn)[-1]
+            if ext.lower() != 'json':
+                continue
+
             nn += 1
 
             if max_num and (nn + 1 >= max_num):
                 print ('ENDING EARLY')
                 return
 
-            fn = join(dir_name, fn)
+            fn = path.join(dir_name, fn)
 
             with open(fn, mode='rb') as f:
                 try:
@@ -143,7 +145,7 @@ def walk_json_dir(dd='getty/json/images',
                     decoded_json = json.loads(content.decode('utf-8'))
                     yield content, decoded_json
                 except ValueError:
-                    print "couldn't decode json from {}".format(fn)
+                    print "couldn't import json from {}".format(fn)
                     continue
 
 

--- a/mediachain/getty/thumbnails.py
+++ b/mediachain/getty/thumbnails.py
@@ -1,0 +1,63 @@
+import requests
+import base64
+import json
+from PIL import Image
+from StringIO import StringIO
+from os import path
+
+
+def thumbnail_url(getty_json):
+    try:
+        thumb = [i['uri'] for i in getty_json['display_sizes']
+                 if i['name'] == 'thumb']
+        return thumb[0]
+    except ValueError:
+        return None
+
+
+def thumb_path(json_file_path):
+    base, _, tail = json_file_path.rpartition('/json/images/')
+    jpg_fn = path.splitext(tail)[0] + '.jpg'
+    return path.join(base, 'downloads', 'thumb', jpg_fn)
+
+
+def get_thumbnail_data(json_file_path, size=(150, 150)):
+    """ Returns the raw, jpeg encoded thumbnail data for the
+    image described by the json at the given path.
+
+    First looks on the filesystem for a saved thumbnail at the path
+    produced by the indexer's getty dump routine.
+
+    If not present, parses the json for the thumbnail uri and downloads.
+
+    If the image is larger than `size`, scales to fit.
+    Returns a byte string of the jpeg-encoded image, or None if the
+    image can't be found or downloaded.
+    """
+    try:
+        thumb = thumb_path(json_file_path)
+        if path.isfile(thumb):
+            img = Image.open(thumb)
+        else:
+            with open(json_file_path) as f:
+                getty_json = json.load(f)
+            uri = thumbnail_url(getty_json)
+            r = requests.get(uri)
+            img = Image.open(StringIO(r.content))
+
+        if (img.size[0] > size[0]) or (img.size[1] > size[1]):
+            img.thumbnail(size, Image.ANTIALIAS)
+
+        # add to ipfs and return the multihash ref
+        buf = StringIO()
+        img.save(buf, "JPEG")
+        buf.seek(0)
+        data = buf.read()
+        return data
+    except (requests.exceptions.RequestException, IOError) as e:
+        print("error getting thumbnail data: " + str(e))
+        return None
+
+
+def make_jpeg_data_uri(data):
+    return 'data:image/jpeg;base64,' + base64.urlsafe_b64encode(data)

--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -9,7 +9,18 @@ from pprint import PrettyPrinter
 def get_and_print_object(host, port, object_id):
     obj = get_object(host, port, object_id)
     pp = PrettyPrinter(indent=2)
-    pp.pprint(obj)
+    pp.pprint(stringify_refs(obj))
+
+
+def stringify_refs(obj):
+    res = {}
+    for k, v in obj.iteritems():
+        if isinstance(v, dict):
+            v = stringify_refs(v)
+        if k == u'@link':
+            v = base58.b58encode(v)
+        res[k] = v
+    return res
 
 
 def get_object(host, port, object_id):

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -34,3 +34,15 @@ class TransactorClient(object):
         req = Transactor_pb2.UpdateRequest(chainCellCbor=cell.to_cbor_bytes())
         ref = self.client.UpdateChain(req, timeout)
         return MultihashReference.from_base58(ref.reference)
+
+    def journal_stream(self, last_block_ref=None, timeout=TIMEOUT_SECS):
+        if isinstance(last_block_ref, MultihashReference):
+            last_block_ref = Transactor_pb2.MultihashReference(
+                reference=last_block_ref.multihash_base58())
+        elif last_block_ref is not None:
+            last_block_ref = Transactor_pb2.MultihashReference(
+                reference=last_block_ref)
+
+        req = Transactor_pb2.JournalStreamRequest(
+            lastJournalBlock=last_block_ref)
+        return self.client.JournalStream(req, timeout)

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -42,10 +42,14 @@ class TransactorClient(object):
         if isinstance(last_block_ref, MultihashReference):
             last_block_ref = last_block_ref.multihash_base58()
 
-        req = Transactor_pb2.JournalStreamRequest(
-            lastJournalBlock=Transactor_pb2.MultihashReference(
-                reference=last_block_ref
-            ))
+        if last_block_ref is None:
+            req = Transactor_pb2.JournalStreamRequest()
+        else:
+            req = Transactor_pb2.JournalStreamRequest(
+                lastJournalBlock=Transactor_pb2.MultihashReference(
+                    reference=last_block_ref
+                ))
+            
         return self.client.JournalStream(req, timeout)
 
     def canonical_stream(self, last_block_ref=None, timeout=TIMEOUT_SECS):

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -37,12 +37,10 @@ class TransactorClient(object):
 
     def journal_stream(self, last_block_ref=None, timeout=TIMEOUT_SECS):
         if isinstance(last_block_ref, MultihashReference):
-            last_block_ref = Transactor_pb2.MultihashReference(
-                reference=last_block_ref.multihash_base58())
-        elif last_block_ref is not None:
-            last_block_ref = Transactor_pb2.MultihashReference(
-                reference=last_block_ref)
+            last_block_ref = last_block_ref.multihash_base58()
 
         req = Transactor_pb2.JournalStreamRequest(
-            lastJournalBlock=last_block_ref)
+            lastJournalBlock=Transactor_pb2.MultihashReference(
+                reference=last_block_ref
+            ))
         return self.client.JournalStream(req, timeout)


### PR DESCRIPTION
hey @parkan :)

@vyzo and I talked it over a bit this morning and are concerned that changing the multihash references for the demo might break things in the transactor, etc.

So this just adds a separate `IpfsDatastore` and only uses it when writing the raw data.  So `meta.rawRef` will resolve to ipfs, but everything else uses the old mulithash logic and goes to dynamo.

This shouldn't really affect us in the future, since we're also planning to make the `metaSource` a first-class field on the base `Record` type, so `meta.rawRef` is going to go away soon anyway.
