### PR TITLE
getty.ingest: drop redundant rawRef from common meta

### DIFF
--- a/mediachain/getty/ingest.py
+++ b/mediachain/getty/ingest.py
@@ -32,8 +32,7 @@ def ingest(host, port, dir_root, max_num=0):
 
 
 def getty_to_mediachain_objects(transactor, raw_ref, getty_json, entities):
-    common_meta = {u'rawRef': raw_ref.to_map(),
-                   u'translatedAt': unicode(datetime.utcnow().isoformat()),
+    common_meta = {u'translatedAt': unicode(datetime.utcnow().isoformat()),
                    u'translator': TRANSLATOR_ID}
 
     artist_name = getty_json['artist']


### PR DESCRIPTION
It is already attached to records via the metaSource field.
