### PR TITLE
store image thumbnails in datastore, add links and base64 urls in meta

### DIFF
--- a/mediachain/getty/ingest.py
+++ b/mediachain/getty/ingest.py
@@ -31,7 +31,7 @@ def ingest(host, port, dir_root, max_num=0):
 
 
 def getty_to_mediachain_objects(transactor, raw_ref, getty_json, entities,
-                                thumbnail_ref=None, thumbnail_uri=None):
+                                thumbnail_ref=None):
     common_meta = {u'rawRef': raw_ref.to_map(),
                    u'translatedAt': unicode(datetime.utcnow().isoformat()),
                    u'translator': TRANSLATOR_ID}
@@ -60,9 +60,6 @@ def getty_to_mediachain_objects(transactor, raw_ref, getty_json, entities,
         m = MultihashReference.from_base58(thumbnail_ref)
         data[u'thumbnail'] = m.to_map()
 
-    if thumbnail_uri is not None:
-        data[u'thumbnail_base64'] = thumbnail_uri
-
     artefact_meta = deepcopy(common_meta)
     artefact_meta.update({u'data': data})
 
@@ -89,17 +86,14 @@ def getty_artefacts(transactor,
         raw_ref = MultihashReference.from_base58(raw_ref_str)
         getty_json = json.loads(content.decode('utf-8'))
 
+        thumbnail_ref = None
         thumbnail_data = get_thumbnail_data(file_name)
         if thumbnail_data is not None:
             thumbnail_ref = datastore.put(thumbnail_data)
-            thumbnail_uri = make_jpeg_data_uri(thumbnail_data)
-        else:
-            thumbnail_ref = None
-            thumbnail_uri = None
-
+            
         yield getty_to_mediachain_objects(
             transactor, raw_ref, getty_json, entities,
-            thumbnail_ref=thumbnail_ref, thumbnail_uri=thumbnail_uri
+            thumbnail_ref=thumbnail_ref
         )
 
 

--- a/mediachain/getty/ingest.py
+++ b/mediachain/getty/ingest.py
@@ -2,9 +2,7 @@ import json
 import sys
 from copy import deepcopy
 from datetime import datetime
-from os import walk
-from os.path import join
-
+from os import walk, path
 from grpc.framework.interfaces.face.face import AbortionError
 
 from mediachain.datastore.data_objects import Artefact, Entity, \
@@ -125,18 +123,22 @@ def dedup_artists(transactor,
     return entities
 
 
-def walk_json_dir(dd='getty/json/images',
+def walk_json_dir(dd='getty',
                   max_num=0):
     nn = 0
     for dir_name, subdir_list, file_list in walk(dd):
         for fn in file_list:
+            ext = path.splitext(fn)[-1]
+            if ext.lower() != 'json':
+                continue
+
             nn += 1
 
             if max_num and (nn + 1 >= max_num):
                 print ('ENDING EARLY')
                 return
 
-            fn = join(dir_name, fn)
+            fn = path.join(dir_name, fn)
 
             with open(fn, mode='rb') as f:
                 try:
@@ -144,5 +146,5 @@ def walk_json_dir(dd='getty/json/images',
                     decoded_json = json.loads(content.decode('utf-8'))
                     yield content, decoded_json
                 except ValueError:
-                    print "couldn't decode json from {}".format(fn)
+                    print "couldn't import json from {}".format(fn)
                     continue

--- a/mediachain/getty/ingest.py
+++ b/mediachain/getty/ingest.py
@@ -84,7 +84,7 @@ def getty_artefacts(transactor,
                     max_num=0):
     entities = dedup_artists(transactor, datastore, dd, max_num)
 
-    for content, getty_json in walk_json_dir(dd, max_num):
+    for content, file_name in walk_json_dir(dd, max_num):
         raw_ref_str = datastore.put(content)
         raw_ref = MultihashReference.from_base58(raw_ref_str)
         getty_json = json.loads(content.decode('utf-8'))

--- a/mediachain/getty/thumbnails.py
+++ b/mediachain/getty/thumbnails.py
@@ -1,0 +1,63 @@
+import requests
+import base64
+import json
+from PIL import Image
+from StringIO import StringIO
+from os import path
+
+
+def thumbnail_url(getty_json):
+    try:
+        thumb = [i['uri'] for i in getty_json['display_sizes']
+                 if i['name'] == 'thumb']
+        return thumb[0]
+    except ValueError:
+        return None
+
+
+def thumb_path(json_file_path):
+    base, _, tail = json_file_path.rpartition('/json/images/')
+    jpg_fn = path.splitext(tail)[0] + '.jpg'
+    return path.join(base, 'downloads', 'thumb', jpg_fn)
+
+
+def get_thumbnail_data(json_file_path, size=(150, 150)):
+    """ Returns the raw, jpeg encoded thumbnail data for the
+    image described by the json at the given path.
+
+    First looks on the filesystem for a saved thumbnail at the path
+    produced by the indexer's getty dump routine.
+
+    If not present, parses the json for the thumbnail uri and downloads.
+
+    If the image is larger than `size`, scales to fit.
+    Returns a byte string of the jpeg-encoded image, or None if the
+    image can't be found or downloaded.
+    """
+    try:
+        thumb = thumb_path(json_file_path)
+        if path.isfile(thumb):
+            img = Image.open(thumb)
+        else:
+            with open(json_file_path) as f:
+                getty_json = json.load(f)
+            uri = thumbnail_url(getty_json)
+            r = requests.get(uri)
+            img = Image.open(StringIO(r.content))
+
+        if (img.size[0] > size[0]) or (img.size[1] > size[1]):
+            img.thumbnail(size, Image.ANTIALIAS)
+
+        # add to ipfs and return the multihash ref
+        buf = StringIO()
+        img.save(buf, "JPEG")
+        buf.seek(0)
+        data = buf.read()
+        return data
+    except (requests.exceptions.RequestException, IOError) as e:
+        print("error getting thumbnail data: " + str(e))
+        return None
+
+
+def make_jpeg_data_uri(data):
+    return 'data:image/jpeg;base64,' + base64.urlsafe_b64encode(data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ enum34==1.1.6
 futures==3.0.5
 grpcio==0.14.0
 jmespath==0.9.0
+Pillow==3.2.0
 protobuf==3.0.0b3
 python-dateutil==2.5.3
 six==1.10.0


### PR DESCRIPTION
This was cherry picked from the yn-demo branch, but with the ipfs bits removed.  Thumbnails are written to the main (dynamo) datastore, and a link is added to the `meta` map.  It also puts a base64-encoded data uri into `meta` for the indexer to use.

We could probably just do the base64 uri, since it's a bit redundant to put the data twice.  Having the image available in ipfs made a bit more sense, but since the dynamo store isn't really public, maybe we don't need to have the image standalone there.
