### PR TITLE
set thumbnail_base64 to fallback value if thumbnail is missing

### DIFF
--- a/mediachain/datastore/dynamo.py
+++ b/mediachain/datastore/dynamo.py
@@ -7,6 +7,7 @@ import time
 import random
 from base58 import b58encode
 from boto3.dynamodb.types import Binary
+from botocore.exceptions import ClientError as DynamoError
 from multihash import encode as multihash_encode, SHA2_256
 
 from mediachain.datastore.data_objects import Record, MultihashReference
@@ -44,7 +45,7 @@ def with_retry(func, *args, **kwargs):
     while True:
         try:
             output = func(*args, **kwargs)
-        except botocore.exceptions.ClientError as e:
+        except DynamoError as e:
             error_code = e.response['Error']['Code']
             if error_code not in RETRYABLE_ERRORS:
                 raise e


### PR DESCRIPTION
In the reader api's `fetch_thumbnails` method, if the thumbnail doesn't exist or can't be fetched from the datastore, sets `meta.data.thumbnail_base64` to the string `"NO_IMAGE"` so the indexer can special-case it. 

Also exposes `botocore.exceptions.ClientError` as `mediachain.datastore.dynamo.DynamoError` for easier catching.
