### PR TITLE
disable http thumbnail downloads by default

### DIFF
--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -94,10 +94,17 @@ def main(arguments=None):
                                help='Max json entries to parse. ' +
                                'Defaults to 0 (no maximum)',
                                default=0)
+    ingest_parser.add_argument('-d', '--download_thumbnails',
+                               type=bool,
+                               dest='download_thumbs',
+                               help='If set, download thumbnails if not found' +
+                                    ' on disk.',
+                               default=False)
 
     SUBCOMMANDS={
         'get': lambda ns: api.get_and_print_object(ns.host, ns.port, ns.object_id),
-        'ingest': lambda ns: ingest.ingest(ns.host, ns.port, ns.dir, ns.max_num)
+        'ingest': lambda ns: ingest.ingest(ns.host, ns.port, ns.dir, ns.max_num,
+                                           ns.download_thumbs)
     }
 
     ns = parser.parse_args(arguments)

--- a/mediachain/getty/ingest.py
+++ b/mediachain/getty/ingest.py
@@ -14,13 +14,13 @@ from mediachain.getty.thumbnails import get_thumbnail_data, make_jpeg_data_uri
 TRANSLATOR_ID = u'GettyTranslator/0.1'
 
 
-def ingest(host, port, dir_root, max_num=0):
+def ingest(host, port, dir_root, max_num=0, download_thumbs=False):
     transactor = TransactorClient(host, port)
     datastore = get_db()
 
     try:
         for artefact, artefact_ref, entity_ref, cell_ref in getty_artefacts(
-            transactor, datastore, dir_root, max_num
+            transactor, datastore, dir_root, max_num, download_thumbs
         ):
             getty_id = artefact.meta[u'data'][u'_id']
             print "Ingested getty image '{0}' {1}".format(
@@ -77,7 +77,8 @@ def getty_to_mediachain_objects(transactor, raw_ref, getty_json, entities,
 def getty_artefacts(transactor,
                     datastore,
                     dd='getty/json/images',
-                    max_num=0):
+                    max_num=0,
+                    download_thumbs=False):
     entities = dedup_artists(transactor, datastore, dd, max_num)
 
     for content, file_name in walk_json_dir(dd, max_num):
@@ -86,7 +87,7 @@ def getty_artefacts(transactor,
         getty_json = json.loads(content.decode('utf-8'))
 
         thumbnail_ref = None
-        thumbnail_data = get_thumbnail_data(file_name)
+        thumbnail_data = get_thumbnail_data(file_name, download=download_thumbs)
         if thumbnail_data is not None:
             thumbnail_ref = datastore.put(thumbnail_data)
             

--- a/mediachain/getty/thumbnails.py
+++ b/mediachain/getty/thumbnails.py
@@ -21,7 +21,7 @@ def thumb_path(json_file_path):
     return path.join(base, 'downloads', 'thumb', jpg_fn)
 
 
-def get_thumbnail_data(json_file_path, size=(150, 150)):
+def get_thumbnail_data(json_file_path, size=(150, 150), download=False):
     """ Returns the raw, jpeg encoded thumbnail data for the
     image described by the json at the given path.
 
@@ -38,12 +38,14 @@ def get_thumbnail_data(json_file_path, size=(150, 150)):
         thumb = thumb_path(json_file_path)
         if path.isfile(thumb):
             img = Image.open(thumb)
-        else:
+        elif download:
             with open(json_file_path) as f:
                 getty_json = json.load(f)
             uri = thumbnail_url(getty_json)
             r = requests.get(uri)
             img = Image.open(StringIO(r.content))
+        else:
+            return None
 
         if (img.size[0] > size[0]) or (img.size[1] > size[1]):
             img.thumbnail(size, Image.ANTIALIAS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ protobuf==3.0.0b3
 python-dateutil==2.5.3
 six==1.10.0
 wheel==0.24.0
+requests==2.10.0
 


### PR DESCRIPTION
Changes the default behavior when ingesting getty data to skip downloading thumbnails over http.  If the `-d` or `--download_thumnails` cli flag is present, it will try to download if the thumbnail can't be found on disk.

Also adds the `requests` package to requirements.txt, since it was missing.
