### PR TITLE
update journal stream for new API, event names

### DIFF
--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -44,7 +44,7 @@ class TransactorClient(object):
 
     def canonical_stream(self, timeout=TIMEOUT_SECS):
         for event in self.journal_stream(timeout):
-            if event.WhichOneof("event") == "chainUpdateEvent":
+            if event.WhichOneof("event") == "updateChainEvent":
                 ref = event.chainUpdated.canonical.reference
                 obj = get_object(self.host, self.port, ref)
                 yield obj

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -38,23 +38,13 @@ class TransactorClient(object):
         ref = self.client.UpdateChain(req, timeout)
         return MultihashReference.from_base58(ref.reference)
 
-    def journal_stream(self, last_block_ref=None, timeout=TIMEOUT_SECS):
-        if isinstance(last_block_ref, MultihashReference):
-            last_block_ref = last_block_ref.multihash_base58()
-
-        if last_block_ref is None:
-            req = Transactor_pb2.JournalStreamRequest()
-        else:
-            req = Transactor_pb2.JournalStreamRequest(
-                lastJournalBlock=Transactor_pb2.MultihashReference(
-                    reference=last_block_ref
-                ))
-            
+    def journal_stream(self, timeout=TIMEOUT_SECS):
+        req = Transactor_pb2.JournalStreamRequest()
         return self.client.JournalStream(req, timeout)
 
-    def canonical_stream(self, last_block_ref=None, timeout=TIMEOUT_SECS):
-        for event in self.journal_stream(last_block_ref, timeout):
-            if event.WhichOneof("event") == "chainUpdated":
+    def canonical_stream(self, timeout=TIMEOUT_SECS):
+        for event in self.journal_stream(timeout):
+            if event.WhichOneof("event") == "chainUpdateEvent":
                 ref = event.chainUpdated.canonical.reference
                 obj = get_object(self.host, self.port, ref)
                 yield obj


### PR DESCRIPTION
This updates the transactor client to use the new event names and `JournalStreamRequest` definition from the streaming rpc changes on the transactor.

Works for me in a simple test at the repl; when you call `journal_stream`, you immediately get the contents of the current block, and on importing a new getty image you get an `insertCanonicalEvent` and an `updateChainEvent`
