### PR TITLE
Update client for new lookup api

### DIFF
--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -2,7 +2,7 @@ import cbor
 from mediachain.getty.thumbnails import make_jpeg_data_uri
 from mediachain.datastore import get_raw_datastore
 from mediachain.datastore.dynamo import get_db, DynamoError
-from mediachain.reader.transactor import get_chain_head
+import mediachain.transactor.client as tx
 import copy
 import base58
 from pprint import PrettyPrinter
@@ -27,8 +27,9 @@ def stringify_refs(obj):
 
 def get_object(host, port, object_id):
     db = get_db()
+    transactor = tx.TransactorClient(host, port)
     base = db.get(object_id)
-    head = get_chain_head(host, port, object_id)
+    head = transactor.get_chain_head(object_id)
     chain = get_object_chain(head, [])
     obj = reduce(chain_folder, chain, base)
 


### PR DESCRIPTION
This removes `mediachain.reader.transactor.py` and pulls its `get_chain_head` function into the main `TransactorClient`.

It also updates `get_chain_head` to use the new `ChainReference` response type, to properly handle nil chains.

I didn't add any error handling, so trying to lookup the chain for a non-existent canonical will fail with a NOT_FOUND `AbortionError`.  But looking up a canonical with an empty chain will just return `None`

Requires a protobuf recompile with the protos from https://github.com/mediachain/mediachain/pull/151
