### PR TITLE
Don't fetch thumbnails when printing, or if type != 'artefact'

### DIFF
--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -9,7 +9,7 @@ from pprint import PrettyPrinter
 
 
 def get_and_print_object(host, port, object_id):
-    obj = get_object(host, port, object_id)
+    obj = get_object(host, port, object_id, fetch_images=False)
     pp = PrettyPrinter(indent=2)
     pp.pprint(stringify_refs(obj))
 
@@ -25,7 +25,7 @@ def stringify_refs(obj):
     return res
 
 
-def get_object(host, port, object_id):
+def get_object(host, port, object_id, fetch_images=True):
     db = get_db()
     transactor = tx.TransactorClient(host, port)
     base = db.get(object_id)
@@ -35,11 +35,13 @@ def get_object(host, port, object_id):
 
     try:
         entity_id = obj['entity']
-        obj['entity'] = get_object(host, port, entity_id)
+        obj['entity'] = get_object(host, port, entity_id, fetch_images)
     except KeyError as e:
         pass
 
-    return fetch_thumbnails(obj)
+    if fetch_images and obj.get('type') == 'artefact':
+        return fetch_thumbnails(obj)
+    return obj
 
 
 def fetch_thumbnails(obj):


### PR DESCRIPTION
This adds a `fetch_images` keyword arg to `reader.api.get_object` to disable thumbnail fetching.  It's set to True by default, so that the code feeding the indexer won't need to change.

Thumbnail fetching is disabled in `get_and_print_object`, so we don't write a ton of base64 data to the console when printing an object.

Also only fetches thumbs for `artefacts`, since entities won't have them.
