### PR TITLE
Add gprc instructions to README "prereqs" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,58 @@ A minimal client for reading data from and importing data into the current
 Mediachain prototype.
 
 ## Installation
+Please see the [prerequisites section](#prerequisites) below before installing.
+
 ```
 pip install .
 ```
 
-This will install the `mediachain` command the the mediachain python module.
+This will install the `mediachain` command and the mediachain python module.
+
+### Prerequisites
+This project uses [grpc](https://grpc.io) to communicate with remote services.
+
+The next release of grpc is expected to have much improved python developer
+tooling, but until then, the best way to get a compatible version of grpc 
+installed is to build it from source.  There are three main components to the
+installation: grpc core, the protobuf compiler, and the grpcio python package.
+
+#### grpc core
+Follow the [grpc install instructions](https://github.com/grpc/grpc/blob/master/INSTALL.md) to build from source, 
+first installing the prerequisites for your platform.
+
+#### protobuf compiler
+
+If you already have a version of `protoc` that's compatible with protobuf 3,
+you can skip this step.
+
+The grpc source includes a compatible protobuf compiler; 
+to install it, first `cd` to the root of the grpc source you checked out above, 
+then:
+
+```bash
+cd third_party/protobuf
+make install
+```
+
+#### grpcio python package
+The python grpc runtime needs to be installed as well.  If you're on OS X, you
+may be able to skip this step, but the currently released version of the 
+`grpcio` python module has connection issues when running on linux.
+ 
+ Make sure you have the python development headers installed for your system
+ (`apt-get install python-dev` on debian and ubuntu-like systems).
+
+In the grpc source root:
+
+```bash
+pip install -r requirements.txt
+GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
+```
+
+Please note that if you're installing into a virtualenv, it should be activated
+before running the above `pip` commands.  If you're installing into a system-wide
+python installation, you may need to run with `sudo` if you get permission errors.
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cbor==1.0.0
 docutils==0.12
 enum34==1.1.6
 futures==3.0.5
-grpcio==0.14.0
+grpcio>=0.14.0
 jmespath==0.9.0
 Pillow==3.2.0
 protobuf==3.0.0b3


### PR DESCRIPTION
This adds some info about installing grpc from source to the readme.  Hopefully we'll be able to remove this soon, when the grpcio-tools package is updated to include the python plugin and the connection bugfix ends up in a release.  So probably when 0.15.0 is released.

Until then, this also includes a change to requirements.txt to loosen the version requirement on `grpcio` to be `>= 0.14.0` instead of `==`.  This will prevent the "from source" version from being replaced with 0.14.0 when you `pip install` the client.
