### PR TITLE
build protos with grpcio-tools, bump grpc to 0.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cbor==1.0.0
 docutils==0.12
 enum34==1.1.6
 futures==3.0.5
-grpcio>=0.14.0
+grpcio>=0.15.0
 jmespath==0.9.0
 Pillow==3.2.0
 protobuf==3.0.0b3
@@ -14,3 +14,4 @@ wheel==0.24.0
 requests==2.10.0
 ipfs-api==0.2.3
 pathlib==1.0.1
+grpcio-tools==0.15.1

--- a/scripts/build_grpc.sh
+++ b/scripts/build_grpc.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PYTHON=${1:-"/usr/bin/env python"}
+
 BASEDIR=$(dirname $0)/..
 PROTOBUF_DIR=$BASEDIR/protobuf
 PROTOS_OUT_DIR=$BASEDIR/mediachain/proto
@@ -10,7 +12,7 @@ rm -f $PROTOS_OUT_DIR/[!_]*
 echo "Regenerating protobuf..."
 
 for file in `ls $PROTOBUF_DIR`; do
-    protoc -I $PROTOBUF_DIR  --python_out=$PROTOS_OUT_DIR --grpc_out=$PROTOS_OUT_DIR --plugin=protoc-gen-grpc=`which grpc_python_plugin` $PROTOBUF_DIR/$file
+    $PYTHON -m grpc.tools.protoc -I $PROTOBUF_DIR  --python_out=$PROTOS_OUT_DIR --grpc_python_out=$PROTOS_OUT_DIR $PROTOBUF_DIR/$file
 done
 
 echo "Done!"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(reqs_file) as f:
 
 def _pre_install(dir):
     from subprocess import check_call
-    check_call(['scripts/build_grpc.sh'],
+    check_call(['scripts/build_grpc.sh', sys.executable],
             cwd=dir) 
 
 class install(_install):


### PR DESCRIPTION
The latest release of grpcio-tools includes a working protoc with python plugin, and the main grpcio package has been updated to include the fix for the connection bug that was requiring us to build from source.

This bumps the gprio depenency to 0.15.0, and uses grpcio-tools to compile the protos in `build_grpc.sh`.

It also adds an optional argument to `build_grpc.sh` which should be the path to the python executable to use; this lets `setup.py` pass in the path to the interpreter it was invoked with, so that `build_gprc.sh` can use a python that has the `grpcio-tools` package installed, even if we're installing to a virtualenv.  If the path isn't given, it will fallback to `/usr/bin/env python`.

Tested by installing into a fresh virtualenv, and everything seems to work.
