### PR TITLE
Fix python packaging woes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 include scripts/*
+include protobuf/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include scripts/*

--- a/scripts/build_grpc.sh
+++ b/scripts/build_grpc.sh
@@ -11,8 +11,19 @@ rm -f $PROTOS_OUT_DIR/[!_]*
 
 echo "Regenerating protobuf..."
 
+if [ ! -d $PROTOBUF_DIR ]
+then
+    echo "Could not find protobuf sources, distribution incomplete"
+    exit 1
+fi
+
 for file in `ls $PROTOBUF_DIR`; do
     $PYTHON -m grpc.tools.protoc -I $PROTOBUF_DIR  --python_out=$PROTOS_OUT_DIR --grpc_python_out=$PROTOS_OUT_DIR $PROTOBUF_DIR/$file
+    if [ $? -ne 0 ]
+    then
+        echo "Failed to generate protobuf for $file!"
+        exit $?
+    fi
 done
 
 echo "Done!"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os, sys
 from setuptools import setup, find_packages
-from setuptools.command.install import install as _install  
+from setuptools.command.build_py import build_py as _build_py
 
 reqs_file = os.path.join(os.path.dirname(os.path.realpath(__file__))
                    , "requirements.txt")
@@ -10,16 +10,16 @@ reqs = None
 with open(reqs_file) as f:
     reqs = f.readlines()
 
-def _pre_install(dir):
+def _pre_build_py(dir):
     from subprocess import check_call
     check_call(['scripts/build_grpc.sh', sys.executable],
             cwd=dir) 
 
-class install(_install):
+class build_py(_build_py):
     def run(self):
-        self.execute(_pre_install, [os.path.dirname(__file__)],
+        self.execute(_pre_build_py, [os.path.dirname(__file__)],
                      msg="Generating protobuf")
-        _install.run(self)
+        _build_py.run(self)
 
 setup(
     version='0.1.0',
@@ -35,7 +35,7 @@ setup(
     },
     url='http://mediachain.io',
     install_requires=reqs,
-    cmdclass={'install': install},
+    cmdclass={'build_py': build_py},
     setup_requires=['pytest-runner>=2.8'],
     tests_require=['pytest>=2.9.2'],
 )


### PR DESCRIPTION
This adds `requirements.txt`, the grpc build scripts, and the protobufs to the MANIFEST.in template so that a source distribution can build correctly, and includes @parkan's exit code check for the `build_grpc.sh` script, so a failure there will fail the install.

It also changes setup.py to compile the protos in the `build_py` hook instead of the `install` hook.  When installing from a source distribution, everything from the source tree gets staged in a `build` dir before the install hook is called.  Our protos were being compiled into the source tree after that happened and weren't ending up in the `build` dir (or the installed build).   The `build_py` hook gets called before staging to the build dir, so putting the proto compilation phase there ensures the generated files get installed correctly.

Apparently [it's not possible to replace a deleted version with a new pacakge](http://stackoverflow.com/questions/21064581/how-to-overwrite-pypi-package-when-doing-upload-from-command-line), so since I uploaded a broken 0.1.1 yesterday, we'll probably have to bump to 0.1.2 to get the fix up to pypi.
