### PR TITLE
yield refs in Writer.write_dataset()

### DIFF
--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -134,7 +134,9 @@ def main(arguments=None):
 
         transactor = TransactorClient(args.host, args.port)
         writer = Writer(transactor, download_remote_assets=args.download_thumbs)
-        writer.write_dataset(iterator)
+
+        for refs in writer.write_dataset(iterator):
+            print('Inserted canonical: {}'.format(refs['canonical']))
 
     SUBCOMMANDS={
         'get': get_cmd,

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -34,7 +34,7 @@ class Writer(object):
             try:
                 refs = self.submit_translator_output(translator_id, translated,
                                                      raw, local_assets)
-                print('Inserted canonical: {}'.format(refs['canonical']))
+                yield refs
             except AbortionError:
                 for line in traceback.format_exception(*sys.exc_info()):
                     print_err(line.rstrip('\n'))


### PR DESCRIPTION
This just yields the `refs` dictionary from successful inserts in `Writer.write_dataset()` - to get the canonical ref you'll want `refs['canonical']`

Moves the line that prints the canonical ref to the console to the `ingest_cmd` in `mediachain.cli.main`

closes #48 
