### PR TITLE
WIP: package output + status messages in dicts yielded by writer iterator 

### DIFF
--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -135,8 +135,24 @@ def main(arguments=None):
         transactor = TransactorClient(args.host, args.port)
         writer = Writer(transactor, download_remote_assets=args.download_thumbs)
 
-        for refs in writer.write_dataset(iterator):
-            print('Inserted canonical: {}'.format(refs['canonical']))
+        for result in writer.write_dataset(iterator):
+            if result['success']:
+                refs = result['refs']
+                print('Inserted canonical: {}'.format(refs['canonical']))
+            else:
+                try:
+                    record_id = result['translated']['canonical']['meta']['data']['_id']
+                except LookupError:
+                    record_id = 'unknown'
+
+                print('Error inserting record with id {id}: '.format(
+                    id=record_id
+                ))
+                print('Error code: {error_code}. Details: {details}'.format(
+                    error_code=result['error_code'],
+                    details=result['error_details']
+                ))
+                print(''.join(result['error_traceback']))
 
     SUBCOMMANDS={
         'get': get_cmd,

--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -149,10 +149,10 @@ def main(arguments=None):
                     id=record_id
                 ))
                 print('Error code: {error_code}. Details: {details}'.format(
-                    error_code=result['error_code'],
-                    details=result['error_details']
+                    error_code=result.get('error_code', 'none'),
+                    details=result.get('error_details', 'none')
                 ))
-                print(''.join(result['error_traceback']))
+                print(''.join(result.get('error_traceback', [])))
 
     SUBCOMMANDS={
         'get': get_cmd,

--- a/mediachain/ingestion/directory_iterator.py
+++ b/mediachain/ingestion/directory_iterator.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import traceback
 from dataset_iterator import DatasetIterator
 
 
@@ -20,26 +22,30 @@ class DirectoryIterator(DatasetIterator):
                     print('ingested {} records, ending'.format(nn))
                     return
 
-                with open(fn, mode='rb') as f:
-                    try:
+                try:
+                    with open(fn, mode='rb') as f:
                         content = f.read()
-                    except IOError as e:
-                        print('error reading from {}: {}'.format(
-                            fn, str(e)
-                        ))
-                        continue
 
-                nn += 1
-                parsed = self.translator.parse(content)
-                translated = self.translator.translate(parsed)
-                local_assets = self.get_local_assets(fn, parsed)
+                    nn += 1
+                    parsed = self.translator.parse(content)
+                    translated = self.translator.translate(parsed)
+                    local_assets = self.get_local_assets(fn, parsed)
 
-                yield {
-                    'translated': translated,
-                    'raw_content': content,
-                    'parsed': parsed,
-                    'local_assets': local_assets
-                }
+                    yield {
+                        'success': True,
+                        'translated': translated,
+                        'raw_content': content,
+                        'parsed': parsed,
+                        'local_assets': local_assets
+                    }
+                except Exception as e:
+                    trace = traceback.format_exception(*sys.exc_info())
+                    yield {
+                        'success': False,
+                        'error': e,
+                        'error_details': e.message,
+                        'error_traceback': trace
+                    }
 
     @staticmethod
     def get_local_assets(metadata_filepath, parsed_metadata):

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -1,6 +1,6 @@
 import cbor
 from grpc.beta import implementations
-
+from mediachain.rpc.utils import with_retry
 from mediachain.datastore.data_objects import MultihashReference
 from mediachain.proto import Transactor_pb2  # pylint: disable=no-name-in-module
 from mediachain.proto import Types_pb2  # pylint: disable=no-name-in-module
@@ -24,12 +24,12 @@ class TransactorClient(object):
             cbor_bytes = cbor.dumps(record)
 
         req = Transactor_pb2.InsertRequest(canonicalCbor=cbor_bytes)
-        ref = self.client.InsertCanonical(req, timeout)
+        ref = with_retry(self.client.InsertCanonical, req, timeout)
         return MultihashReference.from_base58(ref.reference)
 
     def get_chain_head(self, ref, timeout=TIMEOUT_SECS):
         req = Types_pb2.MultihashReference(reference=ref)
-        response = self.client.LookupChain(req, timeout)
+        response = with_retry(self.client.LookupChain, req, timeout)
         if response.WhichOneof('reference') == 'chain':
             return MultihashReference.from_base58(
                 response.chain.reference
@@ -43,12 +43,12 @@ class TransactorClient(object):
             cbor_bytes = cbor.dumps(cell)
 
         req = Transactor_pb2.UpdateRequest(chainCellCbor=cbor_bytes)
-        ref = self.client.UpdateChain(req, timeout)
+        ref = with_retry(self.client.UpdateChain, req, timeout)
         return MultihashReference.from_base58(ref.reference)
 
     def journal_stream(self, timeout=TIMEOUT_SECS):
         req = Transactor_pb2.JournalStreamRequest()
-        return self.client.JournalStream(req, timeout)
+        return with_retry(self.client.JournalStream, req, timeout)
 
     def canonical_stream(self, timeout=TIMEOUT_SECS):
         for event in self.journal_stream(timeout):

--- a/mediachain/translation/translator.py
+++ b/mediachain/translation/translator.py
@@ -22,13 +22,8 @@ class Translator(object):
         :param raw_metadata_bytes: a bytestring containing the raw metadata
         :return: a dict representation of the raw metadata
         """
-        try:
-            return json.loads(raw_metadata_bytes, 'utf-8')
-        except (TypeError, ValueError):
-            raise NotImplementedError(
-                "subclasses should parse raw metadata if they accept formats" +
-                " other than utf-8 json text"
-            )
+        return json.loads(raw_metadata_bytes, 'utf-8')
+
 
     @staticmethod
     def translate(parsed_metadata):

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -38,11 +38,14 @@ class Writer(object):
                        'translated': translated,
                        'raw_content': raw,
                        'refs': refs}
-            except AbortionError as e:
+            except Exception as e:
+                error_code = getattr(e, 'code')
+                error_details = getattr(e, 'details', e.message)
+
                 trace = traceback.format_exception(*sys.exc_info())
                 yield {'success': False,
-                       'error_code': str(e.code),
-                       'error_details': e.details,
+                       'error_code': error_code,
+                       'error_details': error_details,
                        'error_traceback': trace,
                        'translated': translated,
                        'raw_content': raw}

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -37,6 +37,7 @@ class Writer(object):
                 yield {'success': True,
                        'translated': translated,
                        'raw_content': raw,
+                       'parsed': result['parsed'],
                        'refs': refs}
             except Exception as e:
                 error_code = getattr(e, 'code')
@@ -48,7 +49,8 @@ class Writer(object):
                        'error_details': error_details,
                        'error_traceback': trace,
                        'translated': translated,
-                       'raw_content': raw}
+                       'raw_content': raw,
+                       'parsed': result['parsed']}
 
 
     def submit_translator_output(self,

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -28,6 +28,10 @@ class Writer(object):
         translator_id = dataset_iterator.translator.translator_id()
 
         for result in dataset_iterator:
+            if not result.get('success'):
+                yield result
+                continue
+
             translated = result['translated']
             raw = result['raw_content']
             local_assets = result.get('local_assets', {})

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -34,10 +34,19 @@ class Writer(object):
             try:
                 refs = self.submit_translator_output(translator_id, translated,
                                                      raw, local_assets)
-                yield refs
-            except AbortionError:
-                for line in traceback.format_exception(*sys.exc_info()):
-                    print_err(line.rstrip('\n'))
+                yield {'success': True,
+                       'translated': translated,
+                       'raw_content': raw,
+                       'refs': refs}
+            except AbortionError as e:
+                trace = traceback.format_exception(*sys.exc_info())
+                yield {'success': False,
+                       'error_code': str(e.code),
+                       'error_details': e.details,
+                       'error_traceback': trace,
+                       'translated': translated,
+                       'raw_content': raw}
+
 
     def submit_translator_output(self,
                                  translator_id,


### PR DESCRIPTION
This uses the same `with_retry` helper we're already using for the rpc datastore service in the transactor client methods.

grpc `AbortionErrors` with status code `UNAVAILABLE` and `UNKNOWN` will be retried up to 10x before bailing out.

@autoencoder mentioned it would be good to bubble fatal errors up out of the Writer.write_dataset method, but I'm not sure what the correct way to do that is in a generator.  At the moment it will just print the traceback and try the next record in the dataset, but if I throw, that would cancel the whole ingestion.  I could just yield the exception instead of the result, and callers would have to check the type... or else yield a tuple of (maybe_error, maybe_result)...
