### PR TITLE
use backoff / retry for transient transactor rpc errors

### DIFF
--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -1,6 +1,6 @@
 import cbor
 from grpc.beta import implementations
-
+from mediachain.rpc.utils import with_retry
 from mediachain.datastore.data_objects import MultihashReference
 from mediachain.proto import Transactor_pb2  # pylint: disable=no-name-in-module
 from mediachain.proto import Types_pb2  # pylint: disable=no-name-in-module
@@ -24,12 +24,12 @@ class TransactorClient(object):
             cbor_bytes = cbor.dumps(record)
 
         req = Transactor_pb2.InsertRequest(canonicalCbor=cbor_bytes)
-        ref = self.client.InsertCanonical(req, timeout)
+        ref = with_retry(self.client.InsertCanonical, req, timeout)
         return MultihashReference.from_base58(ref.reference)
 
     def get_chain_head(self, ref, timeout=TIMEOUT_SECS):
         req = Types_pb2.MultihashReference(reference=ref)
-        response = self.client.LookupChain(req, timeout)
+        response = with_retry(self.client.LookupChain, req, timeout)
         if response.WhichOneof('reference') == 'chain':
             return MultihashReference.from_base58(
                 response.chain.reference
@@ -43,12 +43,12 @@ class TransactorClient(object):
             cbor_bytes = cbor.dumps(cell)
 
         req = Transactor_pb2.UpdateRequest(chainCellCbor=cbor_bytes)
-        ref = self.client.UpdateChain(req, timeout)
+        ref = with_retry(self.client.UpdateChain, req, timeout)
         return MultihashReference.from_base58(ref.reference)
 
     def journal_stream(self, timeout=TIMEOUT_SECS):
         req = Transactor_pb2.JournalStreamRequest()
-        return self.client.JournalStream(req, timeout)
+        return with_retry(self.client.JournalStream, req, timeout)
 
     def canonical_stream(self, timeout=TIMEOUT_SECS):
         for event in self.journal_stream(timeout):


### PR DESCRIPTION
Just the backoff retry support from #53, which grew into a breaking change.
