### PR TITLE
Enable ipfs by default

### DIFF
--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -39,8 +39,8 @@ def main(arguments=None):
 
             set_ipfs_config(cfg)
 
-            if getattr(ns, 'use_ipfs'):
-                set_use_ipfs_for_raw_data(True)
+            if getattr(ns, 'disable_ipfs'):
+                set_use_ipfs_for_raw_data(False)
         except AttributeError:
             pass
 
@@ -72,11 +72,11 @@ def main(arguments=None):
                         default=10002,
                         help='Port to use when connecting to the datastore ' +
                              'service.')
-    parser.add_argument('-i', '--use-ipfs',
-                        dest='use_ipfs',
+    parser.add_argument('--disable-ipfs',
+                        dest='disable_ipfs',
                         action='store_true',
-                        help='If set, upload images and raw metadata ' +
-                             'to IPFS'
+                        help=('If set, do not upload images and raw metadata '
+                              'to IPFS')
                         )
     parser.add_argument('--ipfs-host',
                         dest='ipfs_host',

--- a/mediachain/datastore/__init__.py
+++ b/mediachain/datastore/__init__.py
@@ -1,7 +1,7 @@
 from ipfs import IpfsDatastore
 from rpc import get_db
 
-__USE_IPFS_FOR_RAW_DATA = False
+__USE_IPFS_FOR_RAW_DATA = True
 
 
 def set_use_ipfs_for_raw_data(use):

--- a/mediachain/datastore/ipfs.py
+++ b/mediachain/datastore/ipfs.py
@@ -1,6 +1,6 @@
 import ipfsApi
+from requests.exceptions import ConnectionError
 from tempfile import NamedTemporaryFile
-from mediachain.datastore.data_objects import MultihashReference
 from mediachain.datastore.utils import multihash_ref, object_for_bytes
 
 __IPFS_CONFIG = {'host': 'localhost', 'port': 5001}
@@ -22,8 +22,16 @@ def get_ipfs_datastore():
 
 
 class IpfsDatastore(object):
-    def __init__(self, host='127.0.0.1', port=5001):
+    def __init__(self, host='localhost', port=5001):
         self.client = ipfsApi.Client(host, port)
+        try:
+            self.client.id()
+        except ConnectionError:
+            raise Exception(
+                'Unable to connect to ipfs API at {}:{} \n'
+                'For ipfs installation instructions see '
+                'https://ipfs.io/docs/install'.format(host, port)
+            )
 
     def put(self, data_object):
         try:


### PR DESCRIPTION
This replaces the `--use-ipfs` flag with `--disable-ipfs`, and enables ipfs for raw data storage by default.

Also raises a friendlier error message in `IpfsDatastore.__init__` if it can't connect to the ipfs API server.
