### PR TITLE
Make rocksdb dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,24 @@
 A client library and minimal command line interface for reading data from and 
 importing data into the current Mediachain prototype.
 
-## Installation
+## Usage
+
+#### Optional dependencies
+The mediachain client uses [rocksdb](http://rocksdb.org/) to store a local
+cache of the transactor blockchain.  This cache is not needed for most simple
+operations, and is therefore optional.  To enable the cache, you'll need to
+install rockdb, and the [pyrocksdb python module](https://github.com/stephan-hof/pyrocksdb)
+
+On macOS, via [homebrew](http://brew.sh/):
+```bash
+$ brew install rocksdb
+$ pip install pyrocksdb
+```
+
+Linux users should follow the [rocksdb installation instructions](https://github.com/facebook/rocksdb/blob/master/INSTALL.md)
+and install from source.
+
+#### Installation
 
 To install, first make sure you're using an up-to-date
 version of `pip`.  You can update `pip` with itself: `pip install -U pip`.
@@ -26,7 +43,6 @@ Please note that if you're installing into a virtualenv, it should be activated
 before running the above `pip` commands.  If you're installing into a system-wide
 python installation, you may need to run with `sudo` if you get permission errors.
 
-## Command Line Usage
 
 ### Configuration
 

--- a/mediachain/transactor/block_cache.py
+++ b/mediachain/transactor/block_cache.py
@@ -1,11 +1,33 @@
 from __future__ import unicode_literals
-import rocksdb
 import os
 from mediachain.datastore import get_db
 from mediachain.datastore.utils import ref_base58, bytes_for_object, \
     object_for_bytes
 from mediachain.datastore.data_objects import MultihashReference
 from mediachain.utils.file import mkdir_p, system_cache_dir
+
+
+class InMemoryCache(object):
+    def __init__(self):
+        self.cache = dict()
+
+    def get(self, key):
+        return self.cache.get(key, None)
+
+    def put(self, key, value):
+        self.cache[key] = value
+
+
+def open_db(path):
+    try:
+        import rocksdb
+        opts = rocksdb.Options(create_if_missing=True)
+        return rocksdb.DB(path, opts)
+    except ImportError:
+        print('using in-memory blockchain cache. please install '
+              'rocksdb to enable persistent cache')
+        return InMemoryCache()
+
 
 __SHARED_BLOCK_CACHE = None
 
@@ -32,20 +54,18 @@ class BlockCache(object):
 
         self.datastore = datastore
         self.cache_path = cache_path
-        opts = rocksdb.Options(create_if_missing=True)
-        self.cache_db = rocksdb.DB(cache_path, opts)
-
+        self.cache_db = open_db(cache_path)
 
     def put(self, block, ref=None):
         block_bytes = bytes_for_object(block)
         if ref is None:
             ref = MultihashReference.for_content(block_bytes)
         ref = ref_base58(ref)
-
         self.cache_db.put(bytes(ref), bytes(block_bytes))
 
     def get(self, block_ref):
         block_ref = bytes(ref_base58(block_ref))
+
         cached = self.cache_db.get(block_ref)
         if cached is not None:
             return object_for_bytes(cached)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ requests==2.10.0
 ipfs-api==0.2.3
 pathlib==1.0.1
 grpcio-tools==0.15.1
-pyrocksdb==0.4


### PR DESCRIPTION
This removes rocksdb from requirements.txt, since clients that just want to write or do `get`s won't need it.  If rocks isn't installed, the BlockCache just uses a dictionary to cache blocks in memory.

Also adds a note to the README about the optional rocks dependency.
