### PR TITLE
rename DirectoryIterator to LocalFileIterator, accept single files

### DIFF
--- a/mediachain/ingestion/directory_iterator.py
+++ b/mediachain/ingestion/directory_iterator.py
@@ -2,44 +2,54 @@ import os
 from dataset_iterator import DatasetIterator
 
 
-class DirectoryIterator(DatasetIterator):
-    def __init__(self, translator, dir_path, limit=None):
-        super(DirectoryIterator, self).__init__(translator, limit=limit)
-        self.dir_path = dir_path
+class LocalFileIterator(DatasetIterator):
+    def __init__(self, translator, root_path, limit=None):
+        super(LocalFileIterator, self).__init__(translator, limit=limit)
+        if not os.path.exists(root_path):
+            raise ValueError('File at path {} does not exist'.format(root_path))
+        
+        self.root_path = root_path
 
     def __iter__(self):
         nn = 0
         limit = self.limit
-        for dir_name, subdir_list, file_list in os.walk(self.dir_path):
-            for fn in file_list:
-                fn = os.path.join(dir_name, fn)
-                if not self.translator.can_translate_file(fn):
+
+        fns = []
+        if os.path.isdir(self.root_path):
+            for dir_name, subdir_list, file_list in os.walk(self.root_path):
+                for fn in file_list:
+                    fn = os.path.join(dir_name, fn)
+                    if self.translator.can_translate_file(fn):
+                        fns.append(fn)
+        else:
+            if self.translator.can_translate_file(self.root_path):
+                fns.append(self.root_path)
+
+        for fn in fns:
+            if limit and (nn + 1 >= limit):
+                print('ingested {} records, ending'.format(nn))
+                return
+
+            with open(fn, mode='rb') as f:
+                try:
+                    content = f.read()
+                except IOError as e:
+                    print('error reading from {}: {}'.format(
+                        fn, str(e)
+                    ))
                     continue
 
-                if limit and (nn + 1 >= limit):
-                    print('ingested {} records, ending'.format(nn))
-                    return
+            nn += 1
+            parsed = self.translator.parse(content)
+            translated = self.translator.translate(parsed)
+            local_assets = self.get_local_assets(fn, parsed)
 
-                with open(fn, mode='rb') as f:
-                    try:
-                        content = f.read()
-                    except IOError as e:
-                        print('error reading from {}: {}'.format(
-                            fn, str(e)
-                        ))
-                        continue
-
-                nn += 1
-                parsed = self.translator.parse(content)
-                translated = self.translator.translate(parsed)
-                local_assets = self.get_local_assets(fn, parsed)
-
-                yield {
-                    'translated': translated,
-                    'raw_content': content,
-                    'parsed': parsed,
-                    'local_assets': local_assets
-                }
+            yield {
+                'translated': translated,
+                'raw_content': content,
+                'parsed': parsed,
+                'local_assets': local_assets
+            }
 
     @staticmethod
     def get_local_assets(metadata_filepath, parsed_metadata):

--- a/mediachain/ingestion/getty_dump_iterator.py
+++ b/mediachain/ingestion/getty_dump_iterator.py
@@ -1,9 +1,9 @@
 from os import path
-from directory_iterator import DirectoryIterator
+from directory_iterator import LocalFileIterator
 import pathlib
 
 
-class GettyDumpIterator(DirectoryIterator):
+class GettyDumpIterator(LocalFileIterator):
     @staticmethod
     def get_local_assets(metadata_filepath, parsed_metadata):
         return {

--- a/tests/translation_test.py
+++ b/tests/translation_test.py
@@ -4,7 +4,7 @@ from mediachain.translation.lookup import get_translator, _TRANSLATORS
 from mediachain.translation.utils import is_mediachain_object, is_canonical, \
     MEDIACHAIN_OBJECT_TAG
 
-from mediachain.ingestion.directory_iterator import DirectoryIterator
+from mediachain.ingestion.directory_iterator import LocalFileIterator
 from mediachain.ingestion.getty_dump_iterator import GettyDumpIterator
 
 from jsonschema import ValidationError
@@ -24,7 +24,7 @@ def get_iterator(data_dir, translator):
     dir_path = os.path.join(data_dir, translator_id)
     if translator_id.startswith('Getty'):
         return GettyDumpIterator(translator, dir_path)
-    return DirectoryIterator(translator, dir_path)
+    return LocalFileIterator(translator, dir_path)
 
 
 # def test_raises_on_nonsense():


### PR DESCRIPTION
This changes DirectorIterator to LocalFileIterator and allows you to pass in either a single file path or a directory.

Also, now raises an exception in **init** if the file doesn't exist.
