### PR TITLE
store binary assets (images) with ipld-style link properties

### DIFF
--- a/mediachain/datastore/rpc.py
+++ b/mediachain/datastore/rpc.py
@@ -1,3 +1,4 @@
+import io
 import functools
 from grpc.beta import implementations
 from grpc.beta.interfaces import StatusCode
@@ -80,3 +81,17 @@ class RpcDatastore(object):
                 return None
             raise
         return object_for_bytes(obj_bytes)
+
+    def open(self, ref, timeout=TIMEOUT_SECS):
+        """
+        Return a file-like object with the binary representation of the
+        object identified by the given ref
+        :param ref: A multihash reference to a binary object in the datastore
+        :param timeout: Seconds to wait before aborting the RPC call
+        :return: A file-like object with the data returned
+        :raises: IOError if no object is found for the given key.
+        """
+        obj_bytes = bytes_for_object(self.get(ref, timeout=timeout))
+        if obj_bytes is None:
+            raise IOError('Unable to fetch object with key {}'.format(ref))
+        return io.BytesIO(obj_bytes)

--- a/mediachain/ingestion/asset_loader.py
+++ b/mediachain/ingestion/asset_loader.py
@@ -2,6 +2,7 @@ import os
 from urlparse import urlparse
 import requests
 import base64
+import mimetypes
 from PIL import Image
 from StringIO import StringIO
 
@@ -10,27 +11,30 @@ def load_asset(asset):
     try:
         uri = asset['uri']
     except (TypeError, KeyError):
-        return None
+        return None, None
+
+    mime, _ = mimetypes.guess_type(uri)
 
     if uri.lower().startswith('file://'):
         p = urlparse(uri)
         file_path = os.path.abspath(os.path.join(p.netloc, p.path))
+
         if not os.path.isfile(file_path):
-            return None
+            return None, None
         try:
             with open(file_path) as f:
-                return f.read()
+                return f.read(), mime
         except IOError as e:
             print('error reading from {}: {}'.format(file_path, e))
-            return
+            return None, None
 
     try:
         r = requests.get(uri)
-        return r.content
+        return r.content, mime
     except requests.exceptions.RequestException as e:
         print('error downloading media from {}: {}'.format(uri, e))
 
-    return None
+    return None, None
 
 
 def process_asset(name, asset_data):

--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -34,20 +34,21 @@ def fetch_thumb_from_datastore(obj):
     try:
         ref = multihash_ref(obj['meta']['data']['thumbnail']['link'])
         db = get_raw_datastore()
-        thumb = db.get(ref)
+        thumb = db.get(ref, timeout=10)
         return thumb
-    except (ValueError, LookupError) as e:
-        print 'error fetching from raw datastore: {}'.format(e)
+    except (ValueError, LookupError,
+            requests.exceptions.RequestException) as e:
+        # print 'error fetching from raw datastore: {}'.format(e)
         return None
 
 
 def fetch_thumb_from_uri(obj):
     try:
         uri = obj['meta']['data']['thumbnail']['uri']
-        req = requests.get(uri)
+        req = requests.get(uri, timeout=10)
         return req.content
     except (LookupError, requests.exceptions.RequestException) as e:
-        print 'error fetching from uri: {}'.format(e)
+        # print 'error fetching from uri: {}'.format(e)
         return None
 
 

--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -1,17 +1,14 @@
-from mediachain.datastore import get_db, get_raw_datastore
-from mediachain.ingestion.asset_loader import make_jpeg_data_uri
+from mediachain.datastore import get_db
 import copy
 import base58
-import json
-from pygments import highlight
 from utils import dump
 
 def get_and_print_object(transactor, object_id):
-    obj = get_object(transactor, object_id, fetch_images=False)
+    obj = get_object(transactor, object_id)
     dump(obj)
 
 
-def get_object(transactor, object_id, fetch_images=True):
+def get_object(transactor, object_id):
     db = get_db()
     base = db.get(object_id)
     head = transactor.get_chain_head(object_id)
@@ -20,40 +17,11 @@ def get_object(transactor, object_id, fetch_images=True):
 
     try:
         entity_id = obj['entity']
-        obj['entity'] = get_object(transactor, entity_id, fetch_images)
+        obj['entity'] = get_object(transactor, entity_id)
     except KeyError as e:
         pass
 
-    if fetch_images and obj.get('type') == 'artefact':
-        return fetch_thumbnails(obj)
     return obj
-
-
-def fetch_thumbnails(obj):
-    def with_fallback():
-        o = copy.deepcopy(obj)
-        if 'meta' not in o:
-            o['meta'] = {}
-        if 'data' not in o['meta']:
-            o['meta']['data'] = {}
-
-        o['meta']['data']['thumbnail_base64'] = 'NO_IMAGE'
-        return o
-
-    try:
-        thumb_ref_bytes = obj['meta']['data']['thumbnail']['@link']
-        thumb_ref = base58.b58encode(thumb_ref_bytes)
-        db = get_raw_datastore()
-        thumb = db.get(thumb_ref)
-    except (ValueError, LookupError):
-        return with_fallback()
-
-    with open('/tmp/thumbnail.jpg', 'wb') as f:
-        f.write(thumb)
-
-    with_thumb = copy.deepcopy(obj)
-    with_thumb['meta']['data']['thumbnail_base64'] = make_jpeg_data_uri(thumb)
-    return with_thumb
 
 
 def apply_update_cell(acc, cell):

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -124,19 +124,26 @@ class Writer(object):
         if data is None and self.download_remote_assets:
             data, mime = load_asset(remote_asset)
         if data is None:
-            return None
-        data = process_asset(name, data)
-        ref = self.store_raw(data)
+            ref = None
+        else:
+            data = process_asset(name, data)
+            ref = self.store_raw(data)
 
         try:
-            link_obj['origin'] = remote_asset['uri']
+            link_obj['uri'] = remote_asset['uri']
         except (TypeError, ValueError):
             pass
         if mime:
             link_obj['mime_type'] = mime
         link_obj['binary_asset'] = True
-        link_obj['link'] = ref.to_map()
-        return link_obj
+        if ref:
+            link_obj['link'] = ref.to_map()
+
+        # if we don't have a uri or an ipfs link, don't write out anything
+        if ('link' in link_obj) or ('uri' in link_obj):
+            return link_obj
+        else:
+            return None
 
     def submit_object(self, obj):
         try:

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -85,19 +85,19 @@ class Writer(object):
 
         for k, a in assets.iteritems():
             local = local_assets.get(k, None)
-            ref = self.store_asset(k, local, a)
-            if ref is None:
+            asset_link = self.store_asset(k, local, a)
+            if asset_link is None:
                 # print('Unable to store asset with key {}, removing'.format(k))
                 del record[k]
             else:
-                record[k] = ref.to_map()
+                record[k] = asset_link
 
         objects = {k: v for k, v in record.iteritems()
                    if isinstance(v, dict)}
 
         for k, o in objects.iteritems():
             flat = self.flatten_record(o, common_meta,
-                                       meta_source, local_assets)
+                                       local_assets, meta_source=meta_source)
             if is_mediachain_object(o):
                 ref = self.submit_object(flat)
                 record[k] = ref.to_map()
@@ -119,13 +119,24 @@ class Writer(object):
         return multihash_ref(ref)
 
     def store_asset(self, name, local_asset, remote_asset):
-        data = load_asset(local_asset)
+        link_obj = dict()
+        data, mime = load_asset(local_asset)
         if data is None and self.download_remote_assets:
-            data = load_asset(remote_asset)
+            data, mime = load_asset(remote_asset)
         if data is None:
             return None
         data = process_asset(name, data)
-        return self.store_raw(data)
+        ref = self.store_raw(data)
+
+        try:
+            link_obj['origin'] = remote_asset['uri']
+        except (TypeError, ValueError):
+            pass
+        if mime:
+            link_obj['mime_type'] = mime
+        link_obj['binary_asset'] = True
+        link_obj['link'] = ref.to_map()
+        return link_obj
 
     def submit_object(self, obj):
         try:


### PR DESCRIPTION
This changes the way we write out image links.  Instead of just writing the link directly, it's embedded in a wrapper object that has `binary_asset: true` set, and also has the origin url and mime type (if possible).

I changed the getty translator and iterator to output all images it can find (so thumb, comp, and preview), all stored in the `meta.data.images` map.  so e.g:

``` json
"images": {
        "comp": {
          "origin": "http://cache1.asset-cache.net/gc/JD6484-001-animal-supervision-gettyimages.jpg?v=1&c=IWSAsset&k=2&d=OA3owSIxYcZu6CTE0v2Nq7xkTFD5%2fH8AEc%2bV4t9URzTj3xVJ2%2bN47LqFBOaJ9O2H&b=NDk1",
          "binary_asset": true,
          "link": {
            "@link": "QmR52eufw5m5DqzSDfRPSGR8pUC4KHyxSDiBia265je2jX"
          },
          "mime_type": "image/jpeg"
        },
        "preview": {
          "origin": "http://cache1.asset-cache.net/gp/JD6484-001.jpg?v=1&c=IWSAsset&k=3&d=OA3owSIxYcZu6CTE0v2Nqz%2btE2GTkH5ibg6NPo%2f0ON0d8HvCv9j88vapnBheEuHz&b=ODY=",
          "binary_asset": true,
          "link": {
            "@link": "QmZtMAvxNrVwM7ZQPR2y3NTNN3ci7DH3qvVQMJCgGTLKVA"
          },
          "mime_type": "image/jpeg"
        },
        "thumb": {
          "origin": "http://cache1.asset-cache.net/xt/JD6484-001.jpg?v=1&g=fs1|0|HG|64|841&s=1&b=RjI4",
          "binary_asset": true,
          "link": {
            "@link": "QmSqVFPygCsb9DRJuFQbYkeKfmCM2Pdv9jEqRASk2197K9"
          },
          "mime_type": "image/jpeg"
        }
      },
```

It might make more sense to use a list instead of a map, to allow unnamed items, etc.  That will need some changes to the writer code tho.

This also adds an `.open` method to the `IpfsDatastore` and `RpcDatastore` classes, which returns a file-like object with the contents of the returned object.

I haven't updated the reader api yet, except to remove the old `thumbnail_base64` code.  This means that field is no longer present, so if the indexer is counting on it existing, this may break things.

The indexer could potentially use this new format as-is by walking the `meta.data` dict and looking for `binary_asset`s.  But it may also be worth updating the reader api to do that and collect the binary links in one place for easier iteration.
