### PR TITLE
define DatasetIterator.next to make it a real iterator

### DIFF
--- a/mediachain/ingestion/dataset_iterator.py
+++ b/mediachain/ingestion/dataset_iterator.py
@@ -4,8 +4,17 @@ class DatasetIterator(object):
     def __init__(self, translator, limit=None):
         self.translator = translator
         self.limit = limit
+        self._iterator = None
 
     def __iter__(self):
+        return self
+
+    def next(self):
+        if self._iterator is None:
+            self._iterator = self.generator()
+        return next(self._iterator)
+
+    def generator(self):
         raise NotImplementedError(
-            'subclasses should yield translated metadata'
+            'subclasses should yield translated metadata and supporting data'
         )

--- a/mediachain/ingestion/directory_iterator.py
+++ b/mediachain/ingestion/directory_iterator.py
@@ -10,7 +10,7 @@ class LocalFileIterator(DatasetIterator):
         
         self.root_path = root_path
 
-    def __iter__(self):
+    def generator(self):
         nn = 0
         limit = self.limit
 


### PR DESCRIPTION
This changes the DatasetIterator base class to define `next` and return `self` from the `__iter__` method.  The main "walker" generator function is now called `generator`, and the `LocalFileIterator` subclass now overrides `generator` instead of `__iter__`.

This gets rid of the confusing `TypeError: LocalFileIterator object is not an iterator` errors by making the `DatasetIterator` into an actual iterator.  
