### PR TITLE
change canonical_stream to return a BlockchainFollower object with map/filter fn

### DIFF
--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -86,9 +86,14 @@ class TransactorClient(object):
 
     def canonical_stream(self, catchup=True, timeout=None):
         def filter_and_map_event(e):
-            if e.WhichOneof('event') != 'insertCanonicalEvent':
+            ref = None
+            if e.WhichOneof('event') == 'insertCanonicalEvent':
+                ref = e.insertCanonicalEvent.reference
+            elif e.WhichOneof('event') == 'updateChainEvent':
+                ref = e.updateChainEvent.canonical.reference
+            if ref is None:
                 return None
-            return reader.get_object(self, e.insertCanonicalEvent.reference)
+            return reader.get_object(self, ref)
 
         return self.journal_stream(catchup=catchup,
                                    timeout=timeout,

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -1,4 +1,6 @@
 import cbor
+from contextlib import contextmanager
+from itertools import ifilter, imap
 from grpc.beta import implementations
 from mediachain.rpc.utils import with_retry
 from mediachain.datastore.data_objects import MultihashReference
@@ -48,7 +50,7 @@ class TransactorClient(object):
         ref = with_retry(self.client.UpdateChain, req, timeout)
         return MultihashReference.from_base58(ref.reference)
 
-    def journal_stream(self, catchup=True, timeout=None):
+    def journal_stream(self, catchup=True, timeout=None, event_map_fn=None):
         """
         A stream of journal events from the mediachain transactor network.
         If `catchup` is True (the default), will fetch the entire history
@@ -77,15 +79,18 @@ class TransactorClient(object):
         """
         req = Transactor_pb2.JournalStreamRequest()
         stream = self.client.JournalStream(req, timeout)
-        follower = BlockchainFollower(stream, catchup)
+        follower = BlockchainFollower(stream, catchup,
+                                      event_map_fn=event_map_fn)
         follower.start()
         return follower
 
+    def canonical_stream(self, catchup=True, timeout=None):
+        def filter_and_map_event(e):
+            if e.WhichOneof('event') != 'insertCanonicalEvent':
+                return None
+            return reader.get_object(self, e.insertCanonicalEvent.reference)
 
-    def canonical_stream(self, timeout=600):
-        for event in self.journal_stream(timeout=timeout):
-            if event.WhichOneof("event") == "updateChainEvent":
-                ref = event.updateChainEvent.canonical.reference
-                obj = reader.get_object(self, ref)
-                yield obj
+        return self.journal_stream(catchup=catchup,
+                                   timeout=timeout,
+                                   event_map_fn=filter_and_map_event)
 


### PR DESCRIPTION
This adds a new parameter to the `BlockchainFollower` constructor, an `event_map_fn` that maps rpc events into whatever you want.  It's actually a combined map / filter fn, really, since if you return `None`, it will skip yielding that event entirely.

With that in place, we can return a `BlockchainFollower` directly from `canonical_stream`, which means that the caller can use the `with client.canonical_stream() as stream` pattern to get the automatic close behavior we need if we want to disable the timeouts.

This won't break the current indexer, since the `BlockchainFollower` can be iterated over directly, and the indexer is currently passing in an explicit timeout.  Once this is in place, the indexer can drop the timeout and use `with / as` to get the infinite stream.

**Note**: this removes the hack that we put in place for `canonical_stream` where it only emits the canonical after the first chain cell.  That no longer makes sense now that we're introducing more translators.  So the `canonical_stream` now yields updated canonicals for each `insertCanonicalEvent` in the stream.  

This means we still need to figure out the potential race condition, where the indexer sees the `insertCanonicalEvent` and requests the folded object before the update cell comes in.

One possible solution is to have the indexer listen for updates and re-request the folded canonical, although ideally we'd like to also keep track of the last known chain head to avoid re-requesting if we've already seen that update.  Anyway, that sounds like a job for a separate PR.
