### PR TITLE
inject translator version hash in get_translator

### DIFF
--- a/mediachain/translation/lookup.py
+++ b/mediachain/translation/lookup.py
@@ -54,5 +54,6 @@ def get_translator(translator_id):
     full_name = '_mediachain.translation.' + name + '.translator'
     translator_module = __import__(full_name, globals(), locals(), [name])
     translator = getattr(translator_module, name.capitalize())
+    translator.set_version(version)
 
     return translator

--- a/mediachain/translation/lookup.py
+++ b/mediachain/translation/lookup.py
@@ -4,10 +4,12 @@ import os
 import shutil
 from os.path import expanduser, dirname, join
 
+
 class ChDir(object):
     """
     Step into a directory temporarily
     """
+
     def __init__(self, path):
         self.old_dir = os.getcwd()
         self.new_dir = path
@@ -18,37 +20,39 @@ class ChDir(object):
     def __exit__(self, *args):
         os.chdir(self.old_dir)
 
+
 def get_translator(translator_id):
-	try:
-		name, version = translator_id.split('@')
-	except ValueError:
-		raise LookupError(
-			"Bad translator id `{}`, must be `name@multihash` format".format(translator_id)
-		)
+    try:
+        name, version = translator_id.split('@')
+    except ValueError:
+        raise LookupError(
+            "Bad translator id `{}`, must be `name@multihash` format".format(
+                translator_id)
+        )
 
-	ipfs = get_ipfs_datastore() # FIXME: memoize this
+    ipfs = get_ipfs_datastore()  # FIXME: memoize this
 
-	base_path = join(expanduser('~'), '.mediachain')
-	path = join(base_path, '_mediachain', 'translation')
-	if not os.path.exists(path):
-	    os.makedirs(path)
-	    # print join(path, '__init__.py')
-	    open(join(path, '__init__.py'), 'a').close()
-	    # print join(dirname(path), '__init__.py')
-	    open(join(dirname(path), '__init__.py'), 'a').close()
+    base_path = join(expanduser('~'), '.mediachain')
+    path = join(base_path, '_mediachain', 'translation')
+    if not os.path.exists(path):
+        os.makedirs(path)
+        # print join(path, '__init__.py')
+        open(join(path, '__init__.py'), 'a').close()
+        # print join(dirname(path), '__init__.py')
+        open(join(dirname(path), '__init__.py'), 'a').close()
 
-	if not os.path.exists(path):
-	    os.makedirs(path)
+    if not os.path.exists(path):
+        os.makedirs(path)
 
-	with ChDir(path):
-		shutil.rmtree(name, ignore_errors=True)
-		translator = ipfs.client.get(version) # FIXME: timeout, error handling
-		os.rename(version, name) # ipfsApi doesn't support -o
+    with ChDir(path):
+        shutil.rmtree(name, ignore_errors=True)
+        translator = ipfs.client.get(version)  # FIXME: timeout, error handling
+        os.rename(version, name)  # ipfsApi doesn't support -o
 
-	sys.path.insert(1, base_path)
+    sys.path.insert(1, base_path)
 
-	full_name = '_mediachain.translation.' + name + '.translator'
-	translator_module = __import__(full_name, globals(), locals(), [name])
-	translator = getattr(translator_module, name.capitalize())
+    full_name = '_mediachain.translation.' + name + '.translator'
+    translator_module = __import__(full_name, globals(), locals(), [name])
+    translator = getattr(translator_module, name.capitalize())
 
-	return translator
+    return translator

--- a/mediachain/translation/translator.py
+++ b/mediachain/translation/translator.py
@@ -5,12 +5,25 @@ from mediachain.translation.utils import is_mediachain_object, is_canonical
 
 
 class Translator(object):
+    __version__ = None
+
+    @classmethod
+    def set_version(cls, version):
+        cls.__version__ = version
+
     @staticmethod
     def translator_id():
         """
         :return: A unique string identifier for the translator
         """
         raise NotImplementedError("subclasses should return a unique string id")
+
+    @classmethod
+    def versioned_id(cls):
+        return '{id}@{version}'.format(
+            id=cls.translator_id(),
+            version=cls.__version__ or 'UNKNOWN_VERSION'
+        )
 
     @staticmethod
     def parse(raw_metadata_bytes):

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -25,7 +25,7 @@ class Writer(object):
         self.download_remote_assets = download_remote_assets
 
     def write_dataset(self, dataset_iterator):
-        translator_id = dataset_iterator.translator.translator_id()
+        translator_id = dataset_iterator.translator.versioned_id()
 
         for result in dataset_iterator:
             translated = result['translated']


### PR DESCRIPTION
this adds a `versioned_id()` class method that checks the `__version__` property of a translator and returns e.g. `getty@QmWsU4MrF28SrYz5Kwdd2i1d1fUozakdUUuHaSUHjNrBcT`.   The version is set in `get_translator`, and the `versioned_id` is used by the writer, so you get e.g.:

``` json
  "meta": {
    "translator": "getty@QmWsU4MrF28SrYz5Kwdd2i1d1fUozakdUUuHaSUHjNrBcT",
    "raw_ref": {
      "@link": "QmNpndJVVS79PyavnLbpaD9BgLBF5akv9NQR7PPjXBKo6D"
    },
   "..."
}
```

It occurs to me that it would be cool if we update the write to output resolvable links to the translators, e.g.

``` json
  "meta": {
    "translator": {
      "id": "getty",
      "version": "QmWsU4MrF28SrYz5Kwdd2i1d1fUozakdUUuHaSUHjNrBcT",
      "link": { "@link": "QmWsU4MrF28SrYz5Kwdd2i1d1fUozakdUUuHaSUHjNrBcT" }
    },
    "..."
}
```

or something.  But happy to defer that for now.
