### PR TITLE
Send higher res thumbnails, enable image download by default

### DIFF
--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -123,12 +123,12 @@ def main(arguments=None):
                                help='Max json entries to parse. ' +
                                'Defaults to 0 (no maximum)',
                                default=0)
-    ingest_parser.add_argument('-d', '--download-thumbnails',
-                               type=bool,
-                               dest='download_thumbs',
-                               help='If set, download thumbnails if not found' +
-                                    ' on disk.',
-                               default=False)
+    ingest_parser.add_argument('--skip-image-downloads',
+                               dest='skip_downloads',
+                               action='store_true',
+                               help=('If set, images referenced in metadata '
+                                     'will not be downloaded and sent to the '
+                                     'datastore.'))
 
     datastore_get_parser = subparsers.add_parser(
         'datastore_get',
@@ -158,7 +158,8 @@ def main(arguments=None):
         iterator = LocalFileIterator(translator, args.dir, args.max_num)
 
         transactor = TransactorClient(args.host, args.port)
-        writer = Writer(transactor, download_remote_assets=args.download_thumbs)
+        writer = Writer(transactor,
+                        download_remote_assets=(not args.skip_downloads))
 
         for refs in writer.write_dataset(iterator):
             print('Inserted canonical: {}'.format(refs['canonical']))

--- a/mediachain/ingestion/asset_loader.py
+++ b/mediachain/ingestion/asset_loader.py
@@ -40,7 +40,7 @@ def process_asset(name, asset_data):
 
 
 # size constants for images
-THUMBNAIL_SIZE = (150, 150)
+THUMBNAIL_SIZE = (1024, 1024)
 
 
 def resize_image(image_data, size=THUMBNAIL_SIZE):


### PR DESCRIPTION
This changes the thumbnail scaling to only scale down to 1024 pixels max, and changes the default ingestion behavior to download thumbnail images from http uris if present in the translator output.

Removes the `--download-thumbnails` flag, and replaces with a `--skip-image-downloads` flag, which will opt you out of downloading images if you have performance concerns, etc.

With this, I can run e.g.

``` bash
mediachain  ingest artsy@QmbX6FdEREGv6SHDA2XGvarcpv7DefBwFuaCzXY5tkbSLp ~/artsy.json
```

and it will give me artsy data including the ipfs link to the thumbnail: 

``` json
"data": {
      "category": "Print",
      "medium": "Etching",
      "artist": "Giovanni Domenico Tiepolo",
      "created_at": "2013-04-03T03:30:26+00:00",
      "title": "The Rest on the Flight, with Holy Family under a Tree",
      "collecting_institution": "National Gallery of Art, Washington D.C.",
      "image_url": "https://d32dm0rphc51dk.cloudfront.net/b2EpUlEJ4LN0o5gzVj1EVw/normalized.jpg",
      "_id": "artsy_515ba252cd4b8ed0b9000ce2",
      "thumbnail": {
        "@link": "QmdxNJocZBQs9xiUMJPY1rQ6ojGR6YWrcuMBgT5SAjSoo7"
      }
    }
  },
```

The indexer will see the `thumbnail_base64` of the larger image.

The getty translator needs to be updated to take advantage of this, since ATM we're using the small "thumb" image, which is only a couple hundred pixels.  We can change that to use the (watermarked) "comp" image instead, and the indexer can scale it down.
