### PR TITLE
wip - update API

### DIFF
--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -208,13 +208,17 @@ def main(arguments=None):
             print('Inserted canonical: {}'.format(refs['canonical']))
 
     def update_cmd(args):
-        raise NotImplementedError('Update command coming soon')
+        translator = get_translator(args.translator_id)
+        iterator = LocalFileIterator(translator, args.input_path)
+        transactor = TransactorClient(args.host, args.port)
+        writer = Writer(transactor)
+        writer.update_with_translator(args.object_id, iterator)
+        get_cmd(args)
 
     def update_direct_cmd(args):
         transactor = TransactorClient(args.host, args.port)
-        writer = Writer(transactor,
-                        download_remote_assets=(not args.skip_downloads))
-        writer.update_artefact(args.object_id, sys.stdin)
+        writer = Writer(transactor)
+        writer.update_artefact_direct(args.object_id, sys.stdin)
         print('updated {ref} with new data. fetching updated record..'.format(
           ref=args.object_id
         ))

--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -228,17 +228,16 @@ def main(arguments=None):
     SUBCOMMANDS={
         'get': get_cmd,
         'ingest': ingest_cmd,
-        'datastore_get': datastore_get_cmd,
+        'datastore-get': datastore_get_cmd,
         'update': update_cmd,
-        'update_direct': update_direct_cmd
+        'update-direct': update_direct_cmd
     }
 
     ns = parser.parse_args(arguments)
     if getattr(ns, 'skip_validation', False):
         os.environ['MEDIACHAIN_SKIP_SCHEMA_VALIDATION'] = 'true'
 
-    subcmd = ns.subcommand.replace('-', '_')
-    fn = SUBCOMMANDS[subcmd]
+    fn = SUBCOMMANDS[ns.subcommand]
 
     configure_datastore(ns)
     configure_ipfs(ns)

--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -155,6 +155,12 @@ def main(arguments=None):
                                type=str,
                                help=('Path to metadata source.\n'
                                      'Should be a single file.'))
+    update_parser.add_argument('--skip-image-downloads',
+                               dest='skip_downloads',
+                               action='store_true',
+                               help=('If set, images referenced in metadata '
+                                     'will not be downloaded and sent to the '
+                                     'datastore.'))
 
     update_direct_parser = subparsers.add_parser(
         'update-direct',
@@ -211,13 +217,15 @@ def main(arguments=None):
         translator = get_translator(args.translator_id)
         iterator = LocalFileIterator(translator, args.input_path)
         transactor = TransactorClient(args.host, args.port)
-        writer = Writer(transactor)
+        writer = Writer(transactor,
+                        download_remote_assets=(not args.skip_downloads))
         writer.update_with_translator(args.object_id, iterator)
         get_cmd(args)
 
     def update_direct_cmd(args):
         transactor = TransactorClient(args.host, args.port)
-        writer = Writer(transactor)
+        writer = Writer(transactor,
+                        download_remote_assets=(not args.skip_downloads))
         writer.update_artefact_direct(args.object_id, sys.stdin)
         print('updated {ref} with new data. fetching updated record..'.format(
           ref=args.object_id

--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -171,13 +171,6 @@ def main(arguments=None):
                                       type=str,
                                       help=('Multihash reference to a '
                                             'mediachain canonical record'))
-    update_direct_parser.add_argument(
-        '--skip-image-downloads',
-        dest='skip_downloads',
-        action='store_true',
-        help=('If set, images referenced in metadata '
-              'will not be downloaded and sent to the '
-              'datastore.'))
 
     datastore_get_parser = subparsers.add_parser(
         'datastore-get',
@@ -224,8 +217,7 @@ def main(arguments=None):
 
     def update_direct_cmd(args):
         transactor = TransactorClient(args.host, args.port)
-        writer = Writer(transactor,
-                        download_remote_assets=(not args.skip_downloads))
+        writer = Writer(transactor)
         writer.update_artefact_direct(args.object_id, sys.stdin)
         print('updated {ref} with new data. fetching updated record..'.format(
           ref=args.object_id

--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -104,15 +104,24 @@ def main(arguments=None):
 
     ingest_parser = subparsers.add_parser(
         'ingest',
-        help='Ingest a directory of scraped Getty JSON data'
+        help='Ingest metadata into the system using a schema translator'
     )
+
+    translator_id_help_text = ('identifier for a schema translator'
+                               'e.g. getty@QmF00... \n'
+                               'Must be in the format of name@hash where '
+                               'name is the name of a translator, and '
+                               'hash is an ipfs multihash that resolves '
+                               'to a specific version of that translator'
+                               )
+
     ingest_parser.add_argument('translator_id',
                                type=str,
-                               help='identifier for a schema translator' +
-                               'e.g. GettyTranslator/0.1')
-    ingest_parser.add_argument('dir',
+                               help=translator_id_help_text)
+    ingest_parser.add_argument('input-path',
                                type=str,
-                               help='Path to getty json directory root')
+                               help=('Path to metadata source.\n'
+                                     'Can be a directory or single file'))
     ingest_parser.add_argument('--skip-validation',
                                dest='skip_validation',
                                action='store_true',
@@ -130,8 +139,42 @@ def main(arguments=None):
                                      'will not be downloaded and sent to the '
                                      'datastore.'))
 
+    update_parser = subparsers.add_parser(
+        'update',
+        help=('Update an existing record with new data using a record in an '
+              'external format and a schema translator.')
+    )
+    update_parser.add_argument('object_id',
+                               type=str,
+                               help=('Multihash reference to a mediachain '
+                                     'canonical record'))
+    update_parser.add_argument('translator_id',
+                               type=str,
+                               help=translator_id_help_text)
+    update_parser.add_argument('input_path',
+                               type=str,
+                               help=('Path to metadata source.\n'
+                                     'Should be a single file.'))
+
+    update_direct_parser = subparsers.add_parser(
+        'update-direct',
+        help='Update an existing record by reading valid mediachain-format '
+             'metadata from standard input.'
+    )
+    update_direct_parser.add_argument('object_id',
+                                      type=str,
+                                      help=('Multihash reference to a '
+                                            'mediachain canonical record'))
+    update_direct_parser.add_argument(
+        '--skip-image-downloads',
+        dest='skip_downloads',
+        action='store_true',
+        help=('If set, images referenced in metadata '
+              'will not be downloaded and sent to the '
+              'datastore.'))
+
     datastore_get_parser = subparsers.add_parser(
-        'datastore_get',
+        'datastore-get',
         help='Get and print an object from the datastore'
     )
     datastore_get_parser.add_argument('object_id',
@@ -155,7 +198,7 @@ def main(arguments=None):
 
     def ingest_cmd(args):
         translator = get_translator(args.translator_id)
-        iterator = LocalFileIterator(translator, args.dir, args.max_num)
+        iterator = LocalFileIterator(translator, args.input_path, args.max_num)
 
         transactor = TransactorClient(args.host, args.port)
         writer = Writer(transactor,
@@ -164,17 +207,34 @@ def main(arguments=None):
         for refs in writer.write_dataset(iterator):
             print('Inserted canonical: {}'.format(refs['canonical']))
 
+    def update_cmd(args):
+        raise NotImplementedError('Update command coming soon')
+
+    def update_direct_cmd(args):
+        transactor = TransactorClient(args.host, args.port)
+        writer = Writer(transactor,
+                        download_remote_assets=(not args.skip_downloads))
+        writer.update_artefact(args.object_id, sys.stdin)
+        print('updated {ref} with new data. fetching updated record..'.format(
+          ref=args.object_id
+        ))
+        get_cmd(args)
+
+
     SUBCOMMANDS={
         'get': get_cmd,
         'ingest': ingest_cmd,
         'datastore_get': datastore_get_cmd,
+        'update': update_cmd,
+        'update_direct': update_direct_cmd
     }
 
     ns = parser.parse_args(arguments)
     if getattr(ns, 'skip_validation', False):
         os.environ['MEDIACHAIN_SKIP_SCHEMA_VALIDATION'] = 'true'
 
-    fn = SUBCOMMANDS[ns.subcommand]
+    subcmd = ns.subcommand.replace('-', '_')
+    fn = SUBCOMMANDS[subcmd]
 
     configure_datastore(ns)
     configure_ipfs(ns)

--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -74,12 +74,24 @@ def fetch_thumbnails(obj):
     return with_thumb
 
 
+def merge(a, b, path=None):
+    "merges b into a"
+    if path is None: path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                merge(a[key], b[key], path + [str(key)])
+            else:
+                a[key] = b[key]
+        else:
+            a[key] = b[key]
+    return a
+
 def apply_update_cell(acc, cell):
     result = copy.deepcopy(acc)
     cell = copy.deepcopy(cell)
 
-    for k, v in cell['meta'].iteritems():
-        result['meta'][k] = v
+    merge(result['meta'], cell['meta'])
 
     return result
 

--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -122,4 +122,4 @@ def get_object_chain(reference, acc):
     except KeyError as e:
         next_ref = None
 
-    return get_object_chain(next_ref, acc + [obj])
+    return get_object_chain(next_ref, [obj] + acc)

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -11,6 +11,7 @@ from grpc.framework.interfaces.face.face import AbortionError
 from mediachain.datastore.utils import multihash_ref
 import sys
 import traceback
+import json
 
 
 def print_err(*args, **kwargs):
@@ -24,7 +25,14 @@ class Writer(object):
         self.datastore = datastore or get_db()
         self.download_remote_assets = download_remote_assets
 
-    def update_artefact(self, artefact_ref, update_meta):
+    def update_artefact(self, artefact_ref, update_meta_source):
+        if hasattr(update_meta_source, 'read'):
+            update_meta = json.load(update_meta_source)
+        elif isinstance(update_meta_source, basestring):
+            update_meta = json.loads(update_meta_source)
+        else:
+            update_meta = update_meta_source
+
         artefact_ref = multihash_ref(artefact_ref)
         update_cell = {
             'type': 'artefactUpdate',

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -24,6 +24,15 @@ class Writer(object):
         self.datastore = datastore or get_db()
         self.download_remote_assets = download_remote_assets
 
+    def update_artefact(self, artefact_ref, update_meta):
+        artefact_ref = multihash_ref(artefact_ref)
+        update_cell = {
+            'type': 'artefactUpdate',
+            'ref': artefact_ref.to_map(),
+            'meta': update_meta
+        }
+        return self.submit_object(update_cell)
+
     def write_dataset(self, dataset_iterator):
         translator = dataset_iterator.translator
         translator_info = {


### PR DESCRIPTION
#78

So far just adds a very simple `Writer.update_artefact` method that accepts a canonical ref and a `meta` dictionary, and submits an `artefactUpdate` cell.  It doesn't try to do any translation or schema validation, etc.

I fixed up a couple things in the `reader.api` - we were applying the chain updates in reverse order, and we weren't merging dictionaries, so e.g. updating `meta.data` would overwrite any existing value there.

I'm not yet sure what the best way to expose the update command is... having this freeform method is fine (once we run it through the schema validation), but we should also support updating an existing record with new translations of external data, which is a bit trickier.

Open to suggestions on that :)
