### PR TITLE
yield tuple of (ref, object) from canonical_stream

### DIFF
--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -93,7 +93,7 @@ class TransactorClient(object):
                 ref = e.updateChainEvent.canonical.reference
             if ref is None:
                 return None
-            return reader.get_object(self, ref)
+            return ref, reader.get_object(self, ref)
 
         return self.journal_stream(catchup=catchup,
                                    timeout=timeout,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class build_py(_build_py):
         _build_py.run(self)
 
 setup(
-    version='0.1.6',
+    version='0.1.7',
     name='mediachain-client',
     description='mediachain reader command line interface',
     author='Mediachain Labs',


### PR DESCRIPTION
Changes `canonical_stream` to yield a tuple of `(canonical_ref, canonical)`

This will let the indexer know about the canonical ref of the objects in the stream.  Yields the base58 string form of the canonical ref.
