### PR TITLE
separate binary asset loading from get_object api

### DIFF
--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -4,6 +4,7 @@ import copy
 import base58
 import requests
 import contextlib
+from io import BytesIO
 from utils import dump
 
 def get_and_print_object(transactor, object_id):
@@ -42,8 +43,9 @@ def open_binary_asset(asset, timeout=None):
     # If not, try to get the http url if present
     try:
         uri = asset['uri']
-        resp = requests.get(uri, stream=True, timeout=timeout)
-        return contextlib.closing(resp.raw)
+        resp = requests.get(uri, timeout=timeout)
+        f = BytesIO(resp.content)
+        return contextlib.closing(f)
     except (LookupError, requests.exceptions.RequestException):
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class build_py(_build_py):
         _build_py.run(self)
 
 setup(
-    version='0.1.7',
+    version='0.1.8',
     name='mediachain-client',
     description='mediachain reader command line interface',
     author='Mediachain Labs',


### PR DESCRIPTION
This removes the thumbnail fetching from the `get_object` method (and `canonical_stream`, which uses it).  Instead, it exposes a new `open_binary_asset` method, which accepts the asset dictionary and returns a file-like object that will contain the object.  It will try to fetch from ipfs first if there's an ipfs link present, otherwise will try to fetch the http uri.
