### PR TITLE
include sha256 hash in asset dict

### DIFF
--- a/mediachain/ingestion/asset_loader.py
+++ b/mediachain/ingestion/asset_loader.py
@@ -37,26 +37,5 @@ def load_asset(asset):
     return None, None
 
 
-def process_asset(name, asset_data):
-    if name == 'thumbnail':
-        return resize_image(asset_data, THUMBNAIL_SIZE)
-    return asset_data
-
-
-# size constants for images
-THUMBNAIL_SIZE = (1024, 1024)
-
-
-def resize_image(image_data, size=THUMBNAIL_SIZE):
-    img = Image.open(StringIO(image_data))
-    if (img.size[0] > size[0]) or (img.size[1] > size[1]):
-        img.thumbnail(size, Image.ANTIALIAS)
-    buf = StringIO()
-    img.save(buf, "JPEG")
-    buf.seek(0)
-    data = buf.read()
-    return data
-
-
 def make_jpeg_data_uri(data):
     return 'data:image/jpeg;base64,' + base64.urlsafe_b64encode(data)

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -178,6 +178,7 @@ class Writer(object):
         else:
             ref = self.store_raw(data)
             link_obj['hash_sha256'] = hashlib.sha256(data).hexdigest()
+            link_obj['content_size'] = len(data)
 
         try:
             link_obj['uri'] = remote_asset['uri']

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -12,6 +12,7 @@ from mediachain.datastore.utils import multihash_ref
 import sys
 import traceback
 import json
+import hashlib
 
 
 def print_err(*args, **kwargs):
@@ -177,6 +178,7 @@ class Writer(object):
         else:
             data = process_asset(name, data)
             ref = self.store_raw(data)
+            link_obj['hash_sha256'] = hashlib.sha256(data).hexdigest()
 
         try:
             link_obj['uri'] = remote_asset['uri']

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 from copy import deepcopy
 import re
-from mediachain.ingestion.asset_loader import load_asset, process_asset
+from mediachain.ingestion.asset_loader import load_asset
 from mediachain.translation.utils import is_asset, is_canonical, \
     is_mediachain_object
 from mediachain.datastore import get_db, get_raw_datastore

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -135,7 +135,7 @@ class Writer(object):
 
         for k, a in assets.iteritems():
             local = local_assets.get(k, None)
-            asset_link = self.store_asset(k, local, a)
+            asset_link = self.store_asset(local, a)
             if asset_link is None:
                 # print('Unable to store asset with key {}, removing'.format(k))
                 del record[k]
@@ -168,7 +168,7 @@ class Writer(object):
         ref = store.put(raw_content)
         return multihash_ref(ref)
 
-    def store_asset(self, name, local_asset, remote_asset):
+    def store_asset(self, local_asset, remote_asset):
         link_obj = dict()
         data, mime = load_asset(local_asset)
         if data is None and self.download_remote_assets:
@@ -176,7 +176,6 @@ class Writer(object):
         if data is None:
             ref = None
         else:
-            data = process_asset(name, data)
             ref = self.store_raw(data)
             link_obj['hash_sha256'] = hashlib.sha256(data).hexdigest()
 


### PR DESCRIPTION
this adds a `hash_sha256` field to asset dictionaries that has the hex-encoded sha256 hash of the content.   I didn't call it `image_hash_sha256` because we'll eventually want to support other asset types.

Now that I'm about to open this PR though, I realized that we're resizing the `thumbnail` image in the writer client to 1024px max.  So if you re-download from http, you may get a different hash.  Maybe it's best to skip the resizing?  especially since the indexer is going to resize as well.  The only downside to keeping the original size is potentially having to put very large images into ipfs.
