### PR TITLE
set default timeout for fetching assets to 10s

### DIFF
--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -28,7 +28,7 @@ def get_object(transactor, object_id):
     return obj
 
 
-def open_binary_asset(asset, timeout=None):
+def open_binary_asset(asset, timeout=10):
     if not asset.get('binary_asset', False):
         return None
 


### PR DESCRIPTION
Sadly ipfs tends to hang forever when it can't resolve a hash, so having no timeout by default is bad :)

I picked 10 seconds pretty randomly, we may need to tweak this going forward.
