### PR TITLE
get duplicate canonical ref from grpc metadata

### DIFF
--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -224,5 +224,6 @@ def duplicate_canonical_ref(grpc_error):
 def grpc_error_meta(grpc_error):
     meta = dict()
     for item in grpc_error.initial_metadata:
-        meta[item.key] = item.value
+        k = item.key.lower()
+        meta[k] = item.value
     return meta

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -201,7 +201,7 @@ class Writer(object):
             else:
                 return self.transactor.update_chain(obj)
         except AbortionError as e:
-            ref_str = duplicate_canonical_ref(e.details)
+            ref_str = duplicate_canonical_ref(e)
             if ref_str is None:
                 raise
 
@@ -216,20 +216,13 @@ def merge_meta(obj, meta):
     obj['meta'] = merged
 
 
-# TODO(yusef): replace string parsing hack with grpc error metadata
-# requires support in grpc-java (in master but not yet released)
-
-# this regex will only work for base58 encoded sha2-256 hashes,
-# and will break if we ever change the error message :(
-duplicate_insert_pattern = re.compile(
-    '.*Duplicate Journal Insert.*(Qm[1-9a-km-zA-HJ-NP-Z]{44}).*'
-)
+def duplicate_canonical_ref(grpc_error):
+    meta = grpc_error_meta(grpc_error)
+    return meta.get('reference')
 
 
-def duplicate_canonical_ref(grpc_error_str):
-    m = re.match(duplicate_insert_pattern, grpc_error_str)
-    if not m:
-        return None
-    return m.group(1)
-
-
+def grpc_error_meta(grpc_error):
+    meta = dict()
+    for item in grpc_error.initial_metadata:
+        meta[item.key] = item.value
+    return meta


### PR DESCRIPTION
pulls the `reference` key from the gprc error's `initial_metadata` instead of parsing the error string.  Works with transactor master (deployed on testnet).
