### PR TITLE
backoff / retry for journal stream

### DIFF
--- a/mediachain/rpc/utils.py
+++ b/mediachain/rpc/utils.py
@@ -12,6 +12,7 @@ RETRYABLE_ERRORS = [
 
 
 def with_retry(func, *args, **kwargs):
+    max_attempts = kwargs.pop('max_retry_attempts', MAX_ATTEMPTS)
     try:
         operation = str(func._method)
     except AttributeError:
@@ -29,7 +30,7 @@ def with_retry(func, *args, **kwargs):
             # pylint: disable=raising-non-exception
             if e.code not in RETRYABLE_ERRORS:
                 raise e
-            if attempts >= MAX_ATTEMPTS:
+            if attempts >= max_attempts:
                 print('Operation {} failed after {} attempts'.format(
                     operation, attempts
                 ))

--- a/mediachain/transactor/blockchain_follower.py
+++ b/mediachain/transactor/blockchain_follower.py
@@ -92,7 +92,7 @@ class BlockchainFollower(object):
             self.block_ref_queue.put(chain)
 
     def _receive_incoming_events(self):
-        def worker():
+        def event_receive_worker():
             try:
                 stream = self.stream_func()
                 for event in stream:
@@ -115,7 +115,7 @@ class BlockchainFollower(object):
                     return
                 else:
                     raise
-        with_retry(worker, max_retry_attempts=self.max_retry)
+        with_retry(event_receive_worker, max_retry_attempts=self.max_retry)
 
     def _event_stream(self):
         # block until catchup thread completes

--- a/mediachain/transactor/blockchain_follower.py
+++ b/mediachain/transactor/blockchain_follower.py
@@ -40,8 +40,7 @@ class BlockchainFollower(object):
                 target=self._perform_catchup)
         self.incoming_event_thread = threading.Thread(
             name='journal-stream-listener',
-            target=self._receive_incoming_events
-        )
+            target=self._receive_incoming_events)
         self._event_iterator = self._event_stream()
 
     def __iter__(self):

--- a/mediachain/transactor/blockchain_follower.py
+++ b/mediachain/transactor/blockchain_follower.py
@@ -6,39 +6,43 @@ from collections import deque
 from mediachain.transactor.block_cache import get_block_cache
 from mediachain.proto import Transactor_pb2  # pylint: disable=no-name-in-module
 from mediachain.datastore.utils import ref_base58
+from mediachain.rpc.utils import with_retry
 from grpc.beta.interfaces import StatusCode
 from grpc.framework.interfaces.face.face import AbortionError
 
+
 class BlockchainFollower(object):
     def __init__(self,
-                 journal_stream,
+                 stream_func,
                  catchup = True,
                  block_cache = None,
-                 event_map_fn = None):
+                 event_map_fn = None,
+                 max_retry=20):
         if block_cache is None:
             block_cache = get_block_cache()
 
+        self.max_retry = max_retry
         self.cache = block_cache
-        self.journal_stream = journal_stream
+        self.stream_func = stream_func
         self.block_ref_queue = Queue()
         self.incoming_event_queue = Queue()
         self.caught_up = False
         self.should_catchup = catchup
         self.first_incoming_event_received = False
-        self.catchup_thread = threading.Thread(
-            name='blockchain-catchup',
-            target=self._perform_catchup)
-        self.incoming_event_thread = threading.Thread(
-            name='journal-stream-listener',
-            target=self._receive_incoming_events
-        )
         self.replay_stack = deque()
-        self._event_iterator = self._event_stream()
         self._cancelled = False
         if event_map_fn is None:
             self.event_map_fn = lambda x: x
         else:
             self.event_map_fn = event_map_fn
+        self.catchup_thread = threading.Thread(
+                name='blockchain-catchup',
+                target=self._perform_catchup)
+        self.incoming_event_thread = threading.Thread(
+            name='journal-stream-listener',
+            target=self._receive_incoming_events
+        )
+        self._event_iterator = self._event_stream()
 
     def __iter__(self):
         return self
@@ -49,7 +53,7 @@ class BlockchainFollower(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, *args):
         self.cancel()
         return False
 
@@ -62,7 +66,6 @@ class BlockchainFollower(object):
         self._cancelled = True
         self.block_ref_queue.put('__abort__')
         self.incoming_event_queue.put('__abort__')
-        self.journal_stream.cancel()
 
     def _perform_catchup(self):
         if not self.should_catchup:
@@ -89,23 +92,30 @@ class BlockchainFollower(object):
             self.block_ref_queue.put(chain)
 
     def _receive_incoming_events(self):
-        try:
-            for event in self.journal_stream:
-                if not self.first_incoming_event_received:
-                    self.first_incoming_event_received = True
-                    block_ref = block_event_ref(event)
-                    if block_ref is None:
-                        self.block_ref_queue.put('__abort__')
-                        self.caught_up = True
-                    else:
-                        self.block_ref_queue.put(block_ref)
-                self.incoming_event_queue.put(event)
-        except AbortionError as e:
-            if self._cancelled and e.code == StatusCode.CANCELLED:
-                return
-            else:
-                raise
+        def worker():
+            try:
+                stream = self.stream_func()
+                for event in stream:
+                    if getattr(self, '_cancelled'):
+                        stream.cancel()
+                        return
 
+                    if not self.first_incoming_event_received:
+                        self.first_incoming_event_received = True
+                        block_ref = block_event_ref(event)
+                        if block_ref is None:
+                            self.block_ref_queue.put('__abort__')
+                            self.caught_up = True
+                        else:
+                            self.block_ref_queue.put(block_ref)
+
+                    self.incoming_event_queue.put(event)
+            except AbortionError as e:
+                if self._cancelled and e.code == StatusCode.CANCELLED:
+                    return
+                else:
+                    raise
+        with_retry(worker, max_retry_attempts=self.max_retry)
 
     def _event_stream(self):
         # block until catchup thread completes

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -78,8 +78,9 @@ class TransactorClient(object):
         :return:
         """
         req = Transactor_pb2.JournalStreamRequest()
-        stream = self.client.JournalStream(req, timeout)
-        follower = BlockchainFollower(stream, catchup,
+        def open_stream():
+            return self.client.JournalStream(req, timeout)
+        follower = BlockchainFollower(open_stream, catchup,
                                       event_map_fn=event_map_fn)
         follower.start()
         return follower

--- a/mediachain/transactor/client.py
+++ b/mediachain/transactor/client.py
@@ -78,10 +78,10 @@ class TransactorClient(object):
         :return:
         """
         req = Transactor_pb2.JournalStreamRequest()
-        def open_stream():
-            return self.client.JournalStream(req, timeout)
-        follower = BlockchainFollower(open_stream, catchup,
-                                      event_map_fn=event_map_fn)
+        follower = BlockchainFollower(
+            lambda: self.client.JournalStream(req, timeout),
+            catchup,
+            event_map_fn=event_map_fn)
         follower.start()
         return follower
 


### PR DESCRIPTION
This will try to restart the journal stream if we get a recoverable GRPC error while iterating over it.  It changes `BlockchainFollower` to accept a function that will open the stream, instead of the stream itself.  Then in the event receiver thread, it wraps the whole "open and consume stream" process into a helper method, which it call using the `with_retry` helper.  So, if it gets a recoverable error, it will try to reopen the stream and start again.

This will lead to duplicate entries on the output stream, if you get disconnected partway through, since the new journal stream will start over from the beginning.  We should add some bookkeeping here to track the last received block, etc.   But that's its own issue that we need to tackle separately.
