### PR TITLE
replace print statements with logging module

### DIFF
--- a/mediachain/cli/main.py
+++ b/mediachain/cli/main.py
@@ -13,6 +13,9 @@ def set_grpc_verbosity():
 
 set_grpc_verbosity()
 
+from mediachain.utils.log import config_logging
+config_logging(level=os.environ.get('MEDIACHAIN_VERBOSITY', 'WARNING'))
+
 from mediachain.reader import api
 from mediachain.reader.utils import dump
 from mediachain.datastore import set_use_ipfs_for_raw_data, get_db
@@ -22,6 +25,8 @@ from mediachain.writer import Writer
 from mediachain.translation import get_translator
 from mediachain.ingestion.directory_iterator import LocalFileIterator
 from mediachain.transactor.client import TransactorClient
+
+
 
 
 def main(arguments=None):

--- a/mediachain/ingestion/asset_loader.py
+++ b/mediachain/ingestion/asset_loader.py
@@ -3,11 +3,12 @@ from urlparse import urlparse
 import requests
 import base64
 import mimetypes
-from PIL import Image
-from StringIO import StringIO
+from mediachain.utils.log import get_logger
 
 
 def load_asset(asset):
+    logger = get_logger(__name__)
+
     try:
         uri = asset['uri']
     except (TypeError, KeyError):
@@ -25,14 +26,14 @@ def load_asset(asset):
             with open(file_path) as f:
                 return f.read(), mime
         except IOError as e:
-            print('error reading from {}: {}'.format(file_path, e))
+            logger.error('error reading from {}: {}'.format(file_path, e))
             return None, None
 
     try:
         r = requests.get(uri)
         return r.content, mime
     except requests.exceptions.RequestException as e:
-        print('error downloading media from {}: {}'.format(uri, e))
+        logger.error('error downloading media from {}: {}'.format(uri, e))
 
     return None, None
 

--- a/mediachain/rpc/utils.py
+++ b/mediachain/rpc/utils.py
@@ -1,5 +1,6 @@
 import time
 import random
+from mediachain.utils.log import get_logger
 from grpc.beta.interfaces import StatusCode
 from grpc.framework.interfaces.face.face import AbortionError
 
@@ -12,6 +13,7 @@ RETRYABLE_ERRORS = [
 
 
 def with_retry(func, *args, **kwargs):
+    logger = get_logger(__name__)
     max_attempts = kwargs.pop('max_retry_attempts', MAX_ATTEMPTS)
     try:
         operation = str(func._method)
@@ -31,7 +33,7 @@ def with_retry(func, *args, **kwargs):
             if e.code not in RETRYABLE_ERRORS:
                 raise e
             if attempts >= max_attempts:
-                print('Operation {} failed after {} attempts'.format(
+                logger.error('Operation {} failed after {} attempts'.format(
                     operation, attempts
                 ))
                 raise e
@@ -40,7 +42,7 @@ def with_retry(func, *args, **kwargs):
 
         base_delay = min((BACKOFF_COEFF * (2 ** attempts)) / 1000.0, 60.0)
         delay = random.uniform(0, base_delay)
-        print('Operation {} failed, retrying in {}s'.format(
+        logger.info('Operation {} failed, retrying in {}s'.format(
             operation, delay))
         time.sleep(delay)
         attempts += 1

--- a/mediachain/transactor/block_cache.py
+++ b/mediachain/transactor/block_cache.py
@@ -25,8 +25,8 @@ def open_db(path):
         return rocksdb.DB(path, opts)
     except ImportError:
         logger = get_logger(__name__)
-        logger.info('using in-memory blockchain cache. please install '
-                    'rocksdb to enable persistent cache')
+        logger.warning('using in-memory blockchain cache. please install '
+                       'rocksdb to enable persistent cache')
         return InMemoryCache()
 
 

--- a/mediachain/transactor/block_cache.py
+++ b/mediachain/transactor/block_cache.py
@@ -5,7 +5,7 @@ from mediachain.datastore.utils import ref_base58, bytes_for_object, \
     object_for_bytes
 from mediachain.datastore.data_objects import MultihashReference
 from mediachain.utils.file import mkdir_p, system_cache_dir
-
+from mediachain.utils.log import get_logger
 
 class InMemoryCache(object):
     def __init__(self):
@@ -24,8 +24,9 @@ def open_db(path):
         opts = rocksdb.Options(create_if_missing=True)
         return rocksdb.DB(path, opts)
     except ImportError:
-        print('using in-memory blockchain cache. please install '
-              'rocksdb to enable persistent cache')
+        logger = get_logger(__name__)
+        logger.info('using in-memory blockchain cache. please install '
+                    'rocksdb to enable persistent cache')
         return InMemoryCache()
 
 

--- a/mediachain/translation/translator.py
+++ b/mediachain/translation/translator.py
@@ -2,7 +2,7 @@ import json
 import os
 from jsonschema import validate as validate_schema
 from mediachain.translation.utils import is_mediachain_object, is_canonical
-
+from mediachain.utils.log import get_logger
 
 class Translator(object):
     __version__ = None
@@ -76,7 +76,8 @@ class Translator(object):
         res = cls._translate(parsed_metadata)
         if not os.environ.get('MEDIACHAIN_SKIP_SCHEMA_VALIDATION', False):
             validated = cls.validate(res)
-            print "Found {} valid Mediachain cells".format(validated)
+            logger = get_logger(__name__)
+            logger.info("Found {} valid Mediachain cells".format(validated))
 
         return res
 

--- a/mediachain/utils/log.py
+++ b/mediachain/utils/log.py
@@ -1,0 +1,61 @@
+import logging
+from logging.config import dictConfig
+from copy import deepcopy
+
+BASE_CONFIG = dict(
+    version=1,
+    disable_existing_loggers=False,
+    formatters={
+        'standard': {'format':
+                     '[%(asctime)s %(levelname)s %(name)s] - %(message)s'}
+    },
+    handlers={
+        'null': {'class': 'logging.NullHandler',
+                 'level': logging.DEBUG},
+
+        'console': {'class': 'logging.StreamHandler',
+                    'formatter': 'standard',
+                    'level': logging.DEBUG}
+    },
+    loggers={
+        '': {'handlers': ['null'],
+             'level': logging.DEBUG}
+    }
+)
+
+
+_LOGGER_CONFIG = BASE_CONFIG
+
+
+def get_logger(name):
+    global _LOGGER_CONFIG
+    dictConfig(_LOGGER_CONFIG)
+    return logging.getLogger(name)
+
+
+def config_logging(logger_name='mediachain',
+                   console=True,
+                   filename=None,
+                   filemode='a',
+                   level=logging.DEBUG):
+    config = deepcopy(BASE_CONFIG)
+
+    enabled_handlers = []
+    if console:
+        enabled_handlers.append('console')
+    if filename:
+        config['handlers']['file'] = {'class': 'logging.FileLogger',
+                                      'formatter': 'standard',
+                                      'filename': filename,
+                                      'mode': filemode}
+        enabled_handlers.append('file')
+
+    config['loggers'] = {
+        logger_name: {
+            'handlers': enabled_handlers,
+            'level': level
+        }
+    }
+    global _LOGGER_CONFIG
+    _LOGGER_CONFIG = config
+    dictConfig(config)


### PR DESCRIPTION
#89

adds `mediachain.utils.log` with a `config_logging` method that sets the log level and lets you optionally enable logging to a file. 

when you want to get a logger, you should use `mediachain.utils.log.get_logger` instead of the default `logging.getLogger`, so that the current log configuration will be applied.

If you never call `config_logging`, no log output will be produced; this is the recommended default for libraries, since you want the applications using the lib to determine the log settings.

If you run the `mediachain` cli, we call `config_logging` early in `mediachain.cli.main`, and set the level to the value of the `MEDIACHAIN_VERBOSITY` env var, or `WARNING` if that's not set.
