### PR TITLE
fix BlockchainFollower issue when catchup is disabled

### DIFF
--- a/mediachain/transactor/blockchain_follower.py
+++ b/mediachain/transactor/blockchain_follower.py
@@ -81,6 +81,7 @@ class BlockchainFollower(object):
 
     def _perform_catchup(self):
         if not self.should_catchup:
+            self.catchup_complete.set()
             return
 
         logger = get_logger(__name__)
@@ -124,8 +125,9 @@ class BlockchainFollower(object):
             # first clear out all the queues, and event state,
             # in case we're being called from the retry helper after a stream
             # interruption
-            self.catchup_complete.clear()
-            self.catchup_begin.clear()
+            if self.should_catchup:
+                self.catchup_complete.clear()
+                self.catchup_begin.clear()
             self._clear_queues()
             first_event_received = False
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class build_py(_build_py):
         _build_py.run(self)
 
 setup(
-    version='0.1.10',
+    version='0.1.11',
     name='mediachain-client',
     description='mediachain reader command line interface',
     author='Mediachain Labs',


### PR DESCRIPTION
the recent refactor introduced a bug when running with catchup disabled; we never set the `catchup_complete` event, so the main iterator waits on it forever.

This just sets the flag in the catchup thread if catchup is disabled, and makes sure we don't clear it again during a retry.
