### PR TITLE
error handling for stringify_refs

### DIFF
--- a/mediachain/reader/utils.py
+++ b/mediachain/reader/utils.py
@@ -14,8 +14,11 @@ def stringify_refs(obj):
     for k, v in obj.iteritems():
         if isinstance(v, dict):
             v = stringify_refs(v)
-        if k == u'@link':
-            v = base58.b58encode(v)
+        if k == u'@link' and isinstance(v, basestring):
+            try:
+                v = base58.b58encode(v)
+            except (ValueError, AttributeError, TypeError):
+                pass
         res[k] = v
     return res
 


### PR DESCRIPTION
There's some data in the testnet that has a `@link` key, but a dictionary as a value, which breaks the `stringify_refs` fn.

This just makes sure that the thing we're trying to `b58encode` is a (byte)string, and catch errors during the encoding process.
