### PR TITLE
add retry_if_missing arg to datastore.get, use in reader api

### DIFF
--- a/mediachain/datastore/ipfs.py
+++ b/mediachain/datastore/ipfs.py
@@ -62,7 +62,7 @@ class IpfsDatastore(object):
         hashes = [h['Hash'] for h in result if h['Name'] == name]
         return multihash_ref(hashes[0])
 
-    def get(self, ref, timeout=TIMEOUT_SECS):
+    def get(self, ref, timeout=TIMEOUT_SECS, retry_if_missing=False):
         stream = self.open(ref, timeout=timeout)
         byte_string = stream.read()
         return object_for_bytes(byte_string)

--- a/mediachain/datastore/rpc.py
+++ b/mediachain/datastore/rpc.py
@@ -71,11 +71,15 @@ class RpcDatastore(object):
         self.put_cache.add(ref.multihash)
         return ref
 
-    def get(self, ref, timeout=TIMEOUT_SECS):
+    def get(self, ref, timeout=TIMEOUT_SECS, retry_if_missing=False):
         ref = rpc_ref(ref)
         get_with_retry = functools.partial(with_retry, self.rpc.get)
+        extra_retry_status_codes = []
+        if retry_if_missing:
+            extra_retry_status_codes.append(StatusCode.NOT_FOUND)
+
         try:
-            obj_bytes = get_with_retry(ref, timeout).data
+            obj_bytes = get_with_retry(ref, timeout, extra_retry_status_codes=extra_retry_status_codes).data
         except AbortionError as e:
             if e.code == StatusCode.NOT_FOUND:
                 return None

--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -22,7 +22,7 @@ def get_object(transactor, object_id):
     try:
         entity_id = obj['entity']
         obj['entity'] = get_object(transactor, entity_id)
-    except KeyError as e:
+    except (KeyError, TypeError):
         pass
 
     return obj

--- a/mediachain/reader/api.py
+++ b/mediachain/reader/api.py
@@ -14,7 +14,7 @@ def get_and_print_object(transactor, object_id):
 
 def get_object(transactor, object_id):
     db = get_db()
-    base = db.get(object_id)
+    base = db.get(object_id, retry_if_missing=True)
     head = transactor.get_chain_head(object_id)
     chain = get_object_chain(head, [])
     obj = reduce(chain_folder, chain, base)
@@ -105,7 +105,7 @@ def get_object_chain(reference, acc):
         return acc
 
     db = get_db()
-    obj = db.get(reference)
+    obj = db.get(reference, retry_if_missing=True)
 
     try:
         next_ref = obj['chain']['@link']


### PR DESCRIPTION
this adds a `retry_if_missing` arg to `RpcDatastore.get` that will cause a `StatusCode.NOT_FOUND` exception to retry with the exponential backoff / retry helper.

It also adds the arg to `IpfsDatastore`, but it's ignored; I just figured the two datastores should have the same API.

Updates the calls to `db.get()` in `mediachain.reader.api` to enable retries.
