### PR TITLE
Update to handle PR merge for better spec/test compliance on py-ipfs-api repo

### DIFF
--- a/mediachain/datastore/ipfs.py
+++ b/mediachain/datastore/ipfs.py
@@ -54,7 +54,8 @@ class IpfsDatastore(object):
         # {u'Bytes': 22, u'Name': u'/tmp/foo/bar/tmp7Hobfu'}
         # followed by entries for the file, plus entries for '/tmp', '/tmp/foo',
         # etc.
-        header = result.pop(0)
+        # This handles legacy and latest version of ipfs-api repository
+        header = result.pop(0) if type(result) is list else result
         if 'Hash' in header:
             return header['Hash']
 


### PR DESCRIPTION
With recent updates/fixes to the py-ipfs-api repo, a list is no longer returned.  Without this PR, if a user chooses to install the latest py-ipfs-api repo, a traceback will result within the mediachain-client during ingest as follows:

```
[....]
  File "/Users/.../site-packages/mediachain/writer/writer.py", line 83, in write_dataset
    raw, local_assets)
  File "/Users/.../site-packages/mediachain/writer/writer.py", line 97, in submit_translator_output
    raw_ref = self.store_raw(raw_content)
  File "/Users/.../site-packages/mediachain/writer/writer.py", line 168, in store_raw
    ref = store.put(raw_content)
  File "/Users/.../site-packages/mediachain/datastore/ipfs.py", line 59, in put
    header = result.pop(0)
KeyError: 0
```

I've attempted to maintain backwards compatibility with the old behavior (py-ipfs-api <= 0.2.3) and still work with the new and improved py-ipfs-api repo behavior.
