### PR TITLE
write translator id as unicode string

### DIFF
--- a/mediachain/translation/translator.py
+++ b/mediachain/translation/translator.py
@@ -20,9 +20,9 @@ class Translator(object):
 
     @classmethod
     def versioned_id(cls):
-        return '{id}@{version}'.format(
-            id=cls.translator_id(),
-            version=cls.__version__ or 'UNKNOWN_VERSION'
+        return u'{id}@{version}'.format(
+            id=unicode(cls.translator_id()),
+            version=cls.__version__ or u'UNKNOWN_VERSION'
         )
 
     @staticmethod

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -45,7 +45,7 @@ class Writer(object):
     def update_with_translator(self, canonical_ref, dataset_iterator):
         translator = dataset_iterator.translator
         translator_info = {
-            'id': translator.versioned_id(),
+            'id': unicode(translator.versioned_id()),
         }
         result = next(dataset_iterator)
         translated = result['translated']


### PR DESCRIPTION
Playing with the go reader client, I discovered that we've been writing the translator id as a byte string instead of a unicode string to the cbor records.  My fault, since I should have been returning a unicode string from `Translator.versioned_id`.  This isn't obvious when printing the records in the python client, since they both get printed as strings.  In go, the byte strings are printed as slices with hex digits for each code point.

This makes sure we return unicode from that method, and, just in case, wraps the output in `unicode()`  before writing.
