### PR TITLE
fix pip install / grpc issues 

### DIFF
--- a/scripts/build_grpc.sh
+++ b/scripts/build_grpc.sh
@@ -19,10 +19,11 @@ fi
 
 for file in `ls $PROTOBUF_DIR`; do
     $PYTHON -m grpc.tools.protoc -I $PROTOBUF_DIR  --python_out=$PROTOS_OUT_DIR --grpc_python_out=$PROTOS_OUT_DIR $PROTOBUF_DIR/$file
-    if [ $? -ne 0 ] || [ ! -e $PROTOBUF_DIR/$file ]
+    retval=$?
+    if [ $retval -ne 0 ] 
     then
         echo "Failed to generate protobuf for $file!"
-        exit 1
+        exit $retval
     fi
 done
 

--- a/scripts/build_grpc.sh
+++ b/scripts/build_grpc.sh
@@ -19,10 +19,10 @@ fi
 
 for file in `ls $PROTOBUF_DIR`; do
     $PYTHON -m grpc.tools.protoc -I $PROTOBUF_DIR  --python_out=$PROTOS_OUT_DIR --grpc_python_out=$PROTOS_OUT_DIR $PROTOBUF_DIR/$file
-    if [ $? -ne 0 ]
+    if [ $? -ne 0 ] || [ ! -e $PROTOBUF_DIR/$file ]
     then
         echo "Failed to generate protobuf for $file!"
-        exit $?
+        exit 1
     fi
 done
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os, sys
 import pip
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py as _build_py
+from distutils.version import StrictVersion as V
 
 reqs_file = os.path.join(os.path.dirname(os.path.realpath(__file__))
                    , "requirements.txt")
@@ -11,10 +12,14 @@ reqs = None
 with open(reqs_file) as f:
     reqs = f.readlines()
 
+def assert_min_pip_version():
+    assert V(pip.__version__) >= V('8.0.0'), "pip version is out of date.  please update with 'pip install -U pip'"
+
 def install_grpcio_tools():
     pip.main(['install', 'grpcio-tools==0.15.1'])
 
 def _pre_build_py(dir):
+    assert_min_pip_version()
     install_grpcio_tools()
     from subprocess import check_call
     check_call(['scripts/build_grpc.sh', sys.executable],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class build_py(_build_py):
         _build_py.run(self)
 
 setup(
-    version='0.1.11',
+    version='0.1.12',
     name='mediachain-client',
     description='mediachain reader command line interface',
     author='Mediachain Labs',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os, sys
+import pip
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py as _build_py
 
@@ -10,7 +11,11 @@ reqs = None
 with open(reqs_file) as f:
     reqs = f.readlines()
 
+def install_grpcio_tools():
+    pip.main(['install', 'grpcio-tools==0.15.1'])
+
 def _pre_build_py(dir):
+    install_grpcio_tools()
     from subprocess import check_call
     check_call(['scripts/build_grpc.sh', sys.executable],
             cwd=dir)


### PR DESCRIPTION
fixes up a few things that were breaking `pip install` into a fresh virtualenv
- throws if pip version is less than 8.0.0
- installs grpcio-tools with pip before running build_grpc.sh script
- build_grpc.sh correctly fails if proto compilation fails

I just picked 8.0.0 cause it's a nice round number 😆 but maybe it's better to use the current pip version (8.1.2), since we know for sure it works
