### PR TITLE
fix for missing asset uri and invalid multihash ref

### DIFF
--- a/mediachain/datastore/data_objects.py
+++ b/mediachain/datastore/data_objects.py
@@ -1,5 +1,5 @@
 import cbor
-from multihash import SHA2_256, encode as multihash_encode
+from multihash import SHA2_256, encode as multihash_encode, decode as multihash_decode
 from base58 import b58encode, b58decode
 
 
@@ -18,6 +18,7 @@ class MultihashReference(object):
 
     def __init__(self, multihash):
         self.multihash = bytes(multihash)
+        multihash_decode(self.multihash)  # This will throw a ValueError if multihash is invalid
 
     def __repr__(self):
         return u'MultihashReference: ' + self.multihash_base58()

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -182,7 +182,7 @@ class Writer(object):
 
         try:
             link_obj['uri'] = remote_asset['uri']
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, LookupError):
             pass
         if mime:
             link_obj['mime_type'] = mime

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class build_py(_build_py):
         _build_py.run(self)
 
 setup(
-    version='0.1.12',
+    version='0.1.13',
     name='mediachain-client',
     description='mediachain reader command line interface',
     author='Mediachain Labs',


### PR DESCRIPTION
prevents an exception if a remote `__mediachain_asset__` in the translator output does not have a `uri` key.  This can happen when all you have is a local asset without a remote asset uri.  Now it will still add the local asset to ipfs and not die with a `LookupException`

Also validates the multihash in `MultihashReference.__init__`, since I discovered that if you use the `multihash_ref` helper it can let invalid strings through.
