### PR TITLE
add hash_only arg to datastore.put, and Writer.init, 

### DIFF
--- a/mediachain/datastore/ipfs.py
+++ b/mediachain/datastore/ipfs.py
@@ -40,15 +40,21 @@ class IpfsDatastore(object):
         self.hash_only_cmd = ipfsApi.FileCommand('/add?n=true')
 
     def hash_only(self, filename, **kwargs):
+        """
+        Just return the ipfs hash of the file without adding.
+        To be replaced by the upcoming `ipfs add --local` command,
+        which will add to the local ipfs repo, but not provide the
+        the file to the network.
+        """
         return self.hash_only_cmd.request(self.client._client, filename, **kwargs)
 
-    def put(self, data_object, timeout=TIMEOUT_SECS, hash_only=False):
+    def put(self, data_object, timeout=TIMEOUT_SECS, local=False):
         content = bytes_for_object(data_object)
 
         with NamedTemporaryFile() as f:
             f.write(content)
             f.flush()
-            if hash_only:
+            if local:
                 result = self.hash_only(f.name, timeout=timeout)
             else:
                 result = self.client.add(f.name, timeout=timeout)

--- a/mediachain/datastore/ipfs.py
+++ b/mediachain/datastore/ipfs.py
@@ -72,8 +72,8 @@ class IpfsDatastore(object):
         return multihash_ref(hashes[0])
 
     def get(self, ref, timeout=TIMEOUT_SECS, retry_if_missing=False):
-        stream = self.open(ref, timeout=timeout)
-        byte_string = stream.read()
+        with self.open(ref, timeout=timeout) as stream:
+            byte_string = stream.read()
         return object_for_bytes(byte_string)
 
     def open(self, ref, timeout=TIMEOUT_SECS):

--- a/mediachain/datastore/ipfs.py
+++ b/mediachain/datastore/ipfs.py
@@ -37,13 +37,21 @@ class IpfsDatastore(object):
                 'https://ipfs.io/docs/install'.format(host, port)
             )
 
-    def put(self, data_object, timeout=TIMEOUT_SECS):
+        self.hash_only_cmd = ipfsApi.FileCommand('/add?n=true')
+
+    def hash_only(self, filename, **kwargs):
+        return self.hash_only_cmd.request(self.client._client, filename, **kwargs)
+
+    def put(self, data_object, timeout=TIMEOUT_SECS, hash_only=False):
         content = bytes_for_object(data_object)
 
         with NamedTemporaryFile() as f:
             f.write(content)
             f.flush()
-            result = self.client.add(f.name, timeout=timeout)
+            if hash_only:
+                result = self.hash_only(f.name, timeout=timeout)
+            else:
+                result = self.client.add(f.name, timeout=timeout)
 
         if isinstance(result, basestring):
             return result

--- a/mediachain/datastore/rpc.py
+++ b/mediachain/datastore/rpc.py
@@ -59,11 +59,11 @@ class RpcDatastore(object):
         self.rpc = Datastore_pb2.beta_create_DatastoreService_stub(channel)
         self.put_cache = set()
 
-    def put(self, data_object, timeout=TIMEOUT_SECS):
+    def put(self, data_object, timeout=TIMEOUT_SECS, only_hash=False):
         put_with_retry = functools.partial(with_retry, self.rpc.put)
         byte_string = bytes_for_object(data_object)
         content_hash = MultihashReference.for_content(byte_string)
-        if content_hash.multihash in self.put_cache:
+        if only_hash or content_hash.multihash in self.put_cache:
             return content_hash
 
         req = Datastore_pb2.DataObject(data=byte_string)

--- a/mediachain/datastore/rpc.py
+++ b/mediachain/datastore/rpc.py
@@ -59,11 +59,12 @@ class RpcDatastore(object):
         self.rpc = Datastore_pb2.beta_create_DatastoreService_stub(channel)
         self.put_cache = set()
 
-    def put(self, data_object, timeout=TIMEOUT_SECS, only_hash=False):
+    def put(self, data_object, **kwargs):
+        timeout = kwargs.pop('timeout', TIMEOUT_SECS)
         put_with_retry = functools.partial(with_retry, self.rpc.put)
         byte_string = bytes_for_object(data_object)
         content_hash = MultihashReference.for_content(byte_string)
-        if only_hash or content_hash.multihash in self.put_cache:
+        if content_hash.multihash in self.put_cache:
             return content_hash
 
         req = Datastore_pb2.DataObject(data=byte_string)

--- a/mediachain/datastore/utils.py
+++ b/mediachain/datastore/utils.py
@@ -61,6 +61,9 @@ def bytes_for_object(obj):
 
 def object_for_bytes(obj_bytes):
     try:
-        return cbor.loads(obj_bytes)
+        decoded = cbor.loads(obj_bytes)
+        if isinstance(decoded, dict):
+            return decoded
     except ValueError:
-        return obj_bytes
+        pass
+    return obj_bytes

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -22,11 +22,11 @@ def print_err(*args, **kwargs):
 class Writer(object):
     def __init__(self, transactor, datastore=None,
                  download_remote_assets=False,
-                 only_hash_assets=False):
+                 local_ipfs_only=False):
         self.transactor = transactor
         self.datastore = datastore or get_db()
         self.download_remote_assets = download_remote_assets
-        self.only_hash_assets = only_hash_assets
+        self.local_ipfs = local_ipfs_only
 
     def update_artefact_direct(self, artefact_ref, update_meta_source):
         if hasattr(update_meta_source, 'read'):
@@ -167,7 +167,7 @@ class Writer(object):
 
     def store_raw(self, raw_content):
         store = get_raw_datastore()
-        ref = store.put(raw_content, hash_only=self.only_hash_assets)
+        ref = store.put(raw_content, local=self.local_ipfs)
         return multihash_ref(ref)
 
     def store_asset(self, local_asset, remote_asset):

--- a/mediachain/writer/writer.py
+++ b/mediachain/writer/writer.py
@@ -21,10 +21,12 @@ def print_err(*args, **kwargs):
 
 class Writer(object):
     def __init__(self, transactor, datastore=None,
-                 download_remote_assets=False):
+                 download_remote_assets=False,
+                 only_hash_assets=False):
         self.transactor = transactor
         self.datastore = datastore or get_db()
         self.download_remote_assets = download_remote_assets
+        self.only_hash_assets = only_hash_assets
 
     def update_artefact_direct(self, artefact_ref, update_meta_source):
         if hasattr(update_meta_source, 'read'):
@@ -165,7 +167,7 @@ class Writer(object):
 
     def store_raw(self, raw_content):
         store = get_raw_datastore()
-        ref = store.put(raw_content)
+        ref = store.put(raw_content, hash_only=self.only_hash_assets)
         return multihash_ref(ref)
 
     def store_asset(self, local_asset, remote_asset):


### PR DESCRIPTION
this adds a `hash_only` arg to the `put` method of the ipfs and rpc datastores (defaults to `False`, of course).  This lets us skip the expensive ipfs DHT advertisement, etc when doing bulk ingestions but still get an ipfs hash that will resolve if we go back through and add the asset later.

To use it when ingesting things, the `Writer` should be initialized with the `only_hash_assets` arg set to `True`

also fixes a couple small things I discovered in the repl while adding this:
- `IpfsDatastore.get` wasn't closing the read stream correctly
- the `object_for_bytes` helper was sometimes decoding plain strings as cbor values if they happened to start with valid cbor bytes... e.g. "hello world" would deserialize as a unicode string "ello worl".  So now we only return the decoded value if it's a cbor map
